### PR TITLE
GCW 1998 xcode upgrade

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -130,9 +130,9 @@ namespace :cordova do
   desc "Cordova build {platform}"
   task build: :prepare do
     Dir.chdir(CORDOVA_PATH) do
-      team_id = '6B8FS8W94M'
-      provisioning_profile = '4e899d06-4e25-40b5-8ea3-9d93822e8c55'
-      provisioning_profile = '866b46e8-096e-46a0-97fe-0579091c887e' if(environment === "production")
+      team_id = ENV['IOS_DEVELOPMENT_TEAM_ID']
+      provisioning_profile = ENV['PROVISIONING_PROFILE_STAGING']
+      provisioning_profile = ENV['PROVISIONING_PROFILE_PROD'] if(environment === "production")
       build = (environment == "staging" && platform == 'android') ? "debug" : "release"
       system({"ENVIRONMENT" => environment}, "cordova compile #{platform} --#{build} --device --codeSignIdentity='iPhone Developer' --developmentTeam=#{team_id} --provisioningProfile=#{provisioning_profile}")
     end

--- a/Rakefile
+++ b/Rakefile
@@ -103,7 +103,7 @@ end
 namespace :cordova do
   desc "Install cordova package globally"
   task :install do
-    sh %{ npm list --depth 1 --global cordova; if [ $? -ne 0 ]; then npm install -g cordova@6.5.0; fi }
+    sh %{ npm list --depth 1 --global cordova; if [ $? -ne 0 ]; then npm install -g cordova; fi }
     sh %{ npm list --depth 1 --global cordova-update-config; if [ $? -ne 0 ]; then npm install -g cordova-update-config; fi }
   end
   desc "Cordova prepare {platform}"
@@ -130,8 +130,11 @@ namespace :cordova do
   desc "Cordova build {platform}"
   task build: :prepare do
     Dir.chdir(CORDOVA_PATH) do
+      team_id = '6B8FS8W94M'
+      provisioning_profile = '4e899d06-4e25-40b5-8ea3-9d93822e8c55'
+      provisioning_profile = '866b46e8-096e-46a0-97fe-0579091c887e' if(environment === "production")
       build = (environment == "staging" && platform == 'android') ? "debug" : "release"
-      system({"ENVIRONMENT" => environment}, "cordova compile #{platform} --#{build} --device")
+      system({"ENVIRONMENT" => environment}, "cordova compile #{platform} --#{build} --device --codeSignIdentity='iPhone Developer' --developmentTeam=#{team_id} --provisioningProfile=#{provisioning_profile}")
     end
     # Copy build artifacts
     if ENV["CI"]

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 machine:
+  xcode:
+    version: "9.2"
   environment:
     GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx1024m -XX:+HeapDumpOnOutOfMemoryError"'
     XCODE_SCHEME: stock.goodcity
@@ -18,7 +20,6 @@ dependencies:
     - brew update
     - brew install homebrew/core/node6-lts
     - echo 'export PATH="/usr/local/opt/node@6/bin:$PATH"' >> ~/.circlerc
-    - brew install watchman
     - mkdir -p ${ANDROID_HOME}
     - if ! $(grep -q "Revision=23.0.1" $ANDROID_HOME/tools/source.properties); then (curl -o ~/android-sdk.zip https://dl.google.com/android/repository/tools_r23.0.1-macosx.zip && unzip -d ${ANDROID_HOME} ~/android-sdk.zip) && (( sleep 5 && while [ 1 ]; do sleep 1; echo y; done ) | android update sdk --no-ui --all --filter platform-tools,build-tools-23.0.1,android-23,extra-android-m2repository,extra-google-m2repository); fi
     - if ! (which yarn); then curl -o- -L https://yarnpkg.com/install.sh | bash; fi
@@ -26,7 +27,7 @@ dependencies:
     - yarn install
   post:
     - yarn add --force node-sass
-    - yarn add bower ember-cli@2.12.2 phantomjs-prebuilt cordova
+    - yarn add bower phantomjs-prebuilt
     - yarn add codeclimate-test-reporter
     - bundle install
     - bower install

--- a/cordova/build.json
+++ b/cordova/build.json
@@ -1,12 +1,14 @@
 {
   "ios": {
     "debug": {
-      "codeSignIdentity": "iOS Distribution",
-      "provisioningProfile": "de693213-10b3-4182-b928-5b6be207f743"
+      "codeSignIdentity": "iPhone Developer",
+      "developmentTeam": "6B8FS8W94M",
+      "provisioningProfile": "4e899d06-4e25-40b5-8ea3-9d93822e8c55"
     },
     "release": {
-      "codeSignIdentity": "iOS Distribution",
-      "provisioningProfile": "ff51cc6a-8f9d-4b5c-afb6-8eb2626278ad"
+      "codeSignIdentity": "iPhone Developer",
+      "developmentTeam": "6B8FS8W94M",
+      "provisioningProfile": "866b46e8-096e-46a0-97fe-0579091c887e"
     }
   }
 }

--- a/cordova/config.xml
+++ b/cordova/config.xml
@@ -65,7 +65,7 @@
       <string>To enable you to read inventory barcodes and photograph inventory items.</string>
     </edit-config>
   </platform>
-  <engine name="ios" spec="4.2.0" />
+  <engine name="ios" spec="4.5.4" />
   <engine name="android" spec="~5.1.1" />
   <engine name="windows" spec="~4.3.1" />
   <plugin name="cordova-plugin-statusbar" spec="~2.1.1" />

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "active-model-adapter": "2.1.1",
     "broccoli-asset-rev": "^2.4.2",
     "ember-ajax": "^2.5.1",
-    "ember-cli": "2.12.0",
+    "ember-cli": "2.11.0",
     "ember-cli-app-version": "^2.0.1",
     "ember-cli-coffeescript": "^1.15.0",
     "ember-cli-content-security-policy": "^0.5.0",


### PR DESCRIPTION
Hi Team,
This PR upgrades the following.
- Cordova-ios to `4.5.4`
- XCode to `9.2`
- Cordova to lastest version

Downgrades:
- Ember-cli to 2.11(as it was failing with node engine needed >=4.5 || 6 error, which we already have but 2.11 seemed to be working so downgraded to 2.11)

Removes from Circle.yml
- Cordova(as we're installing cardova in rakefile so not needed)
- ember-cli(installing through package.json so not needed)
- Watchmen(only needed to run test cases, in case watchmen is not installed them ember test falls back to node which is fine)

Changes needed to make XCode `9.2` get working on CI
- Add `developmentTeam` id to build.json or directly to cordova build command (developmentTeam id can be found here => https://developer.apple.com/account/#/membership/6B8FS8W94M )
- From XCode 8 and onwards we need to create `iPhone Development` cert instead of `iPhone Distribution` 
- I created `IOS Development` certificate which can be found here => https://developer.apple.com/account/ios/certificate/development (date: Jul 04, 2019)
- .p12 info can be found on ticket https://jira.crossroads.org.hk/browse/GCW-1998
- I created provisioning profile using this development certificate. To download provisioning profile => https://developer.apple.com/account/ios/profile/limited
- I later uploaded certificate and provisioning profile to CI and specified `developmentTeam` id `provisioningProfile` accordingly.


Reference for Cordova build options:- https://github.com/apache/cordova-ios/blob/master/bin/templates/scripts/cordova/build#L34

**Note**:- I was unable to use build.json file(in cordova root dir) in the build so I'd to add changes directly to Rakefile, if someone finds solution for this then please create a PR for the same.



Please review this PR and let me know if any other changes are require.
Thanks :)