### PR TITLE
GCW 2086 add address to ggv order detail page

### DIFF
--- a/app/models/contact.js
+++ b/app/models/contact.js
@@ -1,7 +1,11 @@
 import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
+import Addressable from './addressable';
 
-export default Model.extend({
-  mobile:     attr('string'),
-  name:       attr('string')
+export default Addressable.extend({
+  name:   attr('string'),
+  mobile: attr('string')
 });
+
+
+

--- a/app/models/contact.js
+++ b/app/models/contact.js
@@ -5,6 +5,3 @@ export default Addressable.extend({
   name:   attr('string'),
   mobile: attr('string')
 });
-
-
-

--- a/app/models/contact.js
+++ b/app/models/contact.js
@@ -1,4 +1,3 @@
-import Model from 'ember-data/model';
 import attr from 'ember-data/attr';
 import Addressable from './addressable';
 

--- a/app/templates/orders/order_transport.hbs
+++ b/app/templates/orders/order_transport.hbs
@@ -118,6 +118,24 @@
               {{model.orderTransport.contact.mobile}}
             </div>
           </div>
+
+          <div class="row">
+            <div class="small-5 large-4 columns">
+              Territory:
+            </div>
+            <div class="small-7 large-8 columns">
+              {{model.orderTransport.contact.address.district.territory.name}}
+            </div>
+          </div>
+
+          <div class="row">
+            <div class="small-5 large-4 columns">
+              District:
+            </div>
+            <div class="small-7 large-8 columns">
+              {{model.orderTransport.contact.address.district.name}}
+            </div>
+          </div>
         {{/if}}
       {{/if}}
     </div>

--- a/tests/unit/model/contact-test.js
+++ b/tests/unit/model/contact-test.js
@@ -1,14 +1,15 @@
 import { test, moduleForModel } from 'ember-qunit';
+import Ember from 'ember';
 
-moduleForModel('contact', 'Contact model',{
-  need:[]
+moduleForModel('contact', 'Contact model', {
+  need:['model:addressable', 'model:address']
 });
 
-test('check attributes', function(assert){
-  var model = this.subject();
-  var mobile = Object.keys(model.toJSON()).indexOf('mobile') > -1;
-  var name = Object.keys(model.toJSON()).indexOf('name') > -1;
+test('Relationships with other models', function(assert){
+  assert.expect(2);
+  var contact = this.store().modelFor('contact');
+  var relationshipAddress = Ember.get(contact, 'relationshipsByName').get('address');
 
-  assert.ok(mobile);
-  assert.ok(name);
+  assert.equal(relationshipAddress.key, "address");
+  assert.equal(relationshipAddress.kind, "belongsTo");
 });


### PR DESCRIPTION
Hi Team,

This PR adds Address detail for GGV transport on GGV page of Orders detail page.

Jira ticket:- https://jira.crossroads.org.hk/browse/GCW-2086

please review it and let me know if any further changes are required.
Thanks