### PR TITLE
Code climate test coverage changes

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,6 @@ machine:
     PILOT_WAIT_PROCESSING_INTERVAL: 60
     ANDROID_HOME: "${HOME}/android-sdk"
     PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin:$HOME/.yarn/bin:${ANDROID_HOME}/tools"
-
 dependencies:
   cache_directories:
     - ~/.yarn
@@ -28,7 +27,8 @@ dependencies:
   post:
     - yarn add --force node-sass
     - yarn add bower phantomjs-prebuilt
-    - yarn add codeclimate-test-reporter
+    - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-darwin-amd64 > ./cc-test-reporter
+    - chmod +x ./cc-test-reporter
     - bundle install
     - bower install
     - PATH=$(npm bin):$PATH; azure-filestore download -f goodcity.keystore:
@@ -41,10 +41,13 @@ test:
     - ember server --port 4203:
         background: true
     - sleep 5
+    - ./cc-test-reporter before-build
   override:
     - COVERAGE=true ember test
   post:
-    - codeclimate-test-reporter < 'coverage/lcov.info'
+    - ./cc-test-reporter format-coverage --output "coverage/codeclimate.json"
+    - ./cc-test-reporter format-coverage -t lcov ./coverage/lcov.info
+    - ./cc-test-reporter upload-coverage -r $CODECLIMATE_REPO_TOKEN
     - ember build
     - echo "Killing ember server to free memory for app build" && killall ember
 


### PR DESCRIPTION
Hi Team,

This PR uses CodeClimate's **test-reporter** as it has support for parallel builds, multiple languages, and will receive ongoing support from CodeClimate in the future. 
The reason for change is we were using  older, deprecated test reporter which wasn't showing code-coverage correctly so we're hoping to fix the issue with this.

Test-reporter:- https://github.com/codeclimate/test-reporter
Configuration:- https://docs.codeclimate.com/docs/configuring-test-coverage

Please take a look and let me know if any further changes are required.
Thanks