### PR TITLE
Missing draft translation

### DIFF
--- a/app/locales/en/translations.coffee
+++ b/app/locales/en/translations.coffee
@@ -86,6 +86,7 @@ I18nTranslationsEn =
   "order":
     "processing": "Processing"
     "submitted": "Submitted"
+    "draft": "Draft"
     "submitted_by": "Submitted By"
     "start_process": "Start Processing"
     "restart_process": "Restart Processing"

--- a/app/locales/zh-tw/translations.coffee
+++ b/app/locales/zh-tw/translations.coffee
@@ -85,6 +85,7 @@ I18nTranslationsEn =
   "order":
     "processing": "處理中"
     "submitted": "訂單已經提交"
+    "draft": "等待提交"
     "start_process": "開始訂單處理"
     "restart_process": "重新開始訂單處理"
     "finish_process": "完成訂單處理"


### PR DESCRIPTION
Hi team, 

A translation is missing in prod.
It only affects draft orders. Was not originally added as drafts are not in the scope of the orders page's design, but actually are available the context of the items/orders page (designating).