### PR TITLE
GCW-2294 relax designation constraint to cancel order

### DIFF
--- a/app/controllers/orders/detail.js
+++ b/app/controllers/orders/detail.js
@@ -92,10 +92,9 @@ export default GoodcityController.extend({
     return (ordersPackages.filterBy('state', "dispatched").length > 0 && !ordersPackages.filterBy('state', 'designated').length);
   },
 
-  //Should only be able to cancel if at least 1 item is designated and 0 is dispatched
+  //Should only be able to cancel if 0 items are dispatched
   canCancelOrder(order) {
-    let ordersPackages = order.get("ordersPackages");
-    return (ordersPackages.filterBy('state', 'designated').length > 0 && !ordersPackages.filterBy('state', 'dispatched').length);
+    return !order.get("ordersPackages").filterBy('state', 'dispatched').length;
   },
 
   actions: {

--- a/app/locales/en/translations.coffee
+++ b/app/locales/en/translations.coffee
@@ -150,7 +150,7 @@ I18nTranslationsEn =
     "first_item_dispatch_warning": "You are dispatching first Item in the Order. This will also change state of the Order to dispatching."
     "close_order_popup": "All items in this order are dispatched. Would you like to close the Order? You will not be able to modify the order after closing it."
     "cancel_item_designate_warning": "This will also change state of the Order to processing from cancelled. Are you sure you want to designate?"
-    "cancel_order_alert": "To cancel the Order, there should be 0 dispatched items and at least 1 designated item."
+    "cancel_order_alert": "To cancel the Order, there should be 0 dispatched items."
 
   "order_transports":
     "gogovan_transport": "Send by van"


### PR DESCRIPTION
Hi Team,

This PR removes constraint `at least 1 designated item required to cancel order and keeps constraint of no dispatched items.`

https://jira.crossroads.org.hk/browse/GCW-2294

I will ask Nokia or someone to change chinese translation once this PR is merged.

Please review.

Thanks.