### PR TITLE
replace submitted_by with created_by

### DIFF
--- a/app/templates/orders/contact.hbs
+++ b/app/templates/orders/contact.hbs
@@ -21,7 +21,7 @@
             Name:
           </div>
           <div class="small-7 columns name">
-            {{model.submittedBy.fullName}}
+            {{model.createdBy.fullName}}
           </div>
         </div>
 
@@ -30,7 +30,7 @@
             Phone Number:
           </div>
           <div class="small-7 columns mobile">
-            {{model.submittedBy.mobile}}
+            {{model.createdBy.mobile}}
           </div>
         </div>
 
@@ -39,7 +39,7 @@
             Email:
           </div>
           <div class="small-7 columns email">
-            {{model.submittedBy.email}}
+            {{model.createdBy.email}}
           </div>
         </div>
       </div>

--- a/app/templates/orders/order_block.hbs
+++ b/app/templates/orders/order_block.hbs
@@ -33,13 +33,13 @@
           </div>
         {{/if}}
 
-        {{#if order.submittedBy}}
+        {{#if order.createdBy}}
           <div class="row">
             <div class="small-4 columns field">
               {{ t "order.submitted_by" }}
             </div>
             <div class="small-8 columns value">
-              {{ order.submittedBy.firstName }} {{ order.submittedBy.lastName }}
+              {{ order.createdBy.firstName }} {{ order.createdBy.lastName }}
             </div>
           </div>
         {{/if}}

--- a/app/templates/orders/summary.hbs
+++ b/app/templates/orders/summary.hbs
@@ -26,7 +26,7 @@
           </div>
           <div class="small-7 columns">
             {{#if model.isGoodCityOrder}}
-              {{model.submittedBy.fullName}}
+              {{model.createdBy.fullName}}
             {{else}}
               {{model.stockitContact.fullName}}
             {{/if}}

--- a/tests/acceptance/order-organisation-and-contact-test.js
+++ b/tests/acceptance/order-organisation-and-contact-test.js
@@ -20,7 +20,7 @@ module('Acceptance: Order summary', {
     var location = FactoryGuy.make("location");
     gc_organisation = FactoryGuy.make("gc_organisation");
     organisation_user = FactoryGuy.make("organisationsUser", { gcOrganisation: gc_organisation, user: user });
-    designation = FactoryGuy.make("designation", { state: "submitted", detailType: "GoodCity", gcOrganisation: gc_organisation, submittedBy: user });
+    designation = FactoryGuy.make("designation", { state: "submitted", detailType: "GoodCity", gcOrganisation: gc_organisation, createdBy: user });
     item1 = FactoryGuy.make("item", { state: "submitted", quantity: 0 , designation: designation});
     orders_package1 = FactoryGuy.make("orders_package", { state: "dispatched", quantity: 1, item: item1, designation: designation });
     var data = {"user_profile": [{"id": 2,"first_name": "David", "last_name": "Dara51", "mobile": "61111111", "user_role_ids": [1]}], "users": [{"id": 2,"first_name": "David", "last_name": "Dara51", "mobile": "61111111"}], "roles": [{"id": 4, "name": "Supervisor"}], "user_roles": [{"id": 1, "user_id": 2, "role_id": 4}]};


### PR DESCRIPTION
Hi Team,

On Stock app order details we were showing submitted_by instead of created_by. 

In case of appoint creation on behalf of user it looks wrong. We should show contact and other details of user for whom we have created order.

![image-2019-01-22-09-44-31-186](https://user-images.githubusercontent.com/8424592/51531178-ce671080-1e62-11e9-92c5-f2396f05022b.png)

Issue mentioned on ticket: https://jira.crossroads.org.hk/browse/GCW-2246

Please review.

Thanks.
