### PR TITLE
Fix: race condition issue causes order state jitters

### DIFF
--- a/app/routes/orders/detail.js
+++ b/app/routes/orders/detail.js
@@ -53,6 +53,7 @@ export default getOrderRoute.extend({
     return this.loadIfAbsent("designation", params.order_id);
  },
 
+  /* jshint ignore:start */
   async afterModel(model) {
     if (!model) {
       return;
@@ -70,6 +71,7 @@ export default getOrderRoute.extend({
     const results = await Ember.RSVP.all(tasks);
     results.forEach(data => this.store.pushPayload(data));
   },
+  /* jshint ignore:end */
 
   setupController(controller, model){
     if(model) {

--- a/app/routes/orders/detail.js
+++ b/app/routes/orders/detail.js
@@ -8,6 +8,13 @@ export default getOrderRoute.extend({
   organisationIdforHistoryRoute: null,
   currentRouteName: null,
 
+  loadIfAbsent(model, id) {
+    // note: using findRecord with reload:false will make a request regardless of whether the data is
+    // present or not. If it is present, it will return immediatly but still proceed to making the request
+    // which can result in weird race conditions later on. We use peek explicitely here to avoid this.
+    return (this.store.peekRecord(model, id) || this.store.findRecord(model, id, { reload: true }));
+  },
+
   setHistoryRoute(routeName, previousRoute) {
     if(routeName === "items.history" || routeName === "items.partial_undesignate") {
       this.set("itemIdforHistoryRoute", previousRoute.params.item_id);
@@ -43,20 +50,25 @@ export default getOrderRoute.extend({
   },
 
   model(params) {
-    return (this.store.peekRecord("designation", params.order_id, { reload: true }) || this.store.findRecord("designation", params.order_id, { reload: true }));
-  },
+    return this.loadIfAbsent("designation", params.order_id);
+ },
 
-  afterModel(model) {
-    var organisation;
-    if(model) {
-      var organisationId = model.get('gcOrganisationId');
-      var ordersPackages = this.store.query("orders_package", {   search_by_order_id: model.get("id") });
-      if(organisationId) {
-        organisation = this.store.findRecord('gcOrganisation', organisationId);
-        this.store.pushPayload(organisation);
-      }
-      this.store.pushPayload(ordersPackages);
+  async afterModel(model) {
+    if (!model) {
+      return;
     }
+
+    const tasks = [
+      this.store.query("orders_package", { search_by_order_id: model.get("id") })
+    ];
+
+    let organisationId = model.get('gcOrganisationId');
+    if(organisationId) {
+      tasks.push(this.loadIfAbsent("gcOrganisation", organisationId));
+    }
+
+    const results = await Ember.RSVP.all(tasks);
+    results.forEach(data => this.store.pushPayload(data));
   },
 
   setupController(controller, model){


### PR DESCRIPTION
Hi team,

Here's a fix for the issue where we set an order to 'processing' and it switches immediately back to the previous state (if done quickly enough).

The cause of this appears to be coming from the `findRecord` ember store method with option : `{reload:false}`
--> in that scenario, Ember will return the local record immediately **however**, it will still make a request in the background regardless (which resolves later on its own, ignoring any promise `await`)
This might seem harmless, but since each request also comes with dependencies, it can actually alter data randomly on the page, with no way for us to track it #emberHell 

A reference: https://stackoverflow.com/questions/39899302/emberjs-findrecord-then-not-waiting-for-resolve
