### PR TITLE
GCW- 2361- Move app version and item create from home screen

### DIFF
--- a/app/controllers/app_menu_list.js
+++ b/app/controllers/app_menu_list.js
@@ -1,9 +1,13 @@
 import Ember from 'ember';
+import config from '../config/environment';
 const { getOwner } = Ember;
 import AjaxPromise from 'stock/utils/ajax-promise';
 
 export default Ember.Controller.extend({
   application: Ember.inject.controller(),
+  stockAppVersion: Ember.computed(function(){
+    return config.cordova.enabled ? config.APP.VERSION : null;
+  }),
 
   getCurrentUser: Ember.computed(function(){
     var store = this.get('store');
@@ -12,7 +16,7 @@ export default Ember.Controller.extend({
   }).volatile(),
 
   orderParams(){
-    let orderParams = {}; 
+    let orderParams = {};
     orderParams.booking_type_id = this.store.peekAll('bookingType').filterBy('identifier', 'appointment').get('firstObject.id');
     orderParams.submitted_by_id = this.get('getCurrentUser.id');
     orderParams.state = 'draft';

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -1,13 +1,8 @@
 import Ember from 'ember';
-import config from '../config/environment';
 
 export default Ember.Controller.extend({
   application: Ember.inject.controller(),
   filterService: Ember.inject.service(),
-
-  stockAppVersion: Ember.computed(function(){
-    return config.cordova.enabled ? config.APP.VERSION : null;
-  }),
 
   actions: {
     logMeOut() {

--- a/app/controllers/search_code.js
+++ b/app/controllers/search_code.js
@@ -16,6 +16,7 @@ export default Ember.Controller.extend({
   searchPlaceholder: t("search.placeholder"),
   i18n: Ember.inject.service(),
   isSearchCodePreviousRoute: Ember.computed.localStorage(),
+  previousPath: null,
 
   allPackageTypes: Ember.computed("fetchMoreResult", function(){
     return this.store.peekAll('code').filterBy('visibleInSelects', true);
@@ -106,12 +107,15 @@ export default Ember.Controller.extend({
     },
 
     cancelSearch() {
+      let previousPath = this.get('previousPath');
       Ember.$("#searchText").blur();
       this.send("clearSearch", true);
       if(this.get("backToNewItem")) {
         this.transitionToRoute("items.new");
+      } else if (previousPath) {
+        this.transitionToRoute(previousPath);
       } else {
-        this.transitionToRoute("index");
+        window.history.back();
       }
     },
 

--- a/app/controllers/search_code.js
+++ b/app/controllers/search_code.js
@@ -16,7 +16,6 @@ export default Ember.Controller.extend({
   searchPlaceholder: t("search.placeholder"),
   i18n: Ember.inject.service(),
   isSearchCodePreviousRoute: Ember.computed.localStorage(),
-  previousPath: null,
 
   allPackageTypes: Ember.computed("fetchMoreResult", function(){
     return this.store.peekAll('code').filterBy('visibleInSelects', true);
@@ -107,15 +106,12 @@ export default Ember.Controller.extend({
     },
 
     cancelSearch() {
-      let previousPath = this.get('previousPath');
       Ember.$("#searchText").blur();
       this.send("clearSearch", true);
       if(this.get("backToNewItem")) {
         this.transitionToRoute("items.new");
-      } else if (previousPath) {
-        this.transitionToRoute(previousPath);
       } else {
-        window.history.back();   //On app refresh previousPath gets clear, using this as default case.
+        window.history.back();
       }
     },
 

--- a/app/controllers/search_code.js
+++ b/app/controllers/search_code.js
@@ -115,7 +115,7 @@ export default Ember.Controller.extend({
       } else if (previousPath) {
         this.transitionToRoute(previousPath);
       } else {
-        window.history.back();
+        window.history.back();   //On app refresh previousPath gets clear, using this as default case.
       }
     },
 

--- a/app/locales/en/translations.coffee
+++ b/app/locales/en/translations.coffee
@@ -29,6 +29,9 @@ I18nTranslationsEn =
   "continue": "Continue"
   "save_changes": "Save changes"
   "discard_changes": "Discard changes"
+  "add_inventory_item": "Add Item to Inventory"
+  "manage_inventory": "Manage Appointment Quotas"
+  "new_order": "Create New Order"
 
   "camera_scan":
     "permission_error": "Camera permission is not turned on."

--- a/app/locales/zh-tw/translations.coffee
+++ b/app/locales/zh-tw/translations.coffee
@@ -25,6 +25,12 @@ I18nTranslationsEn =
   "search_organisation": "搜尋機構"
   "not_now": "稍後"
   "incomplete_form": "請填寫必需填寫之項目以繼續下一步"
+  "continue": "Continue"
+  "save_changes": "Save changes"
+  "discard_changes": "Discard changes"
+  "add_inventory_item": "Add Item to Inventory"
+  "manage_inventory": "Manage Appointment Quotas"
+  "new_order": "Create New Order"
 
   "camera_scan":
     "permission_error": "Camera permission is not turned on."

--- a/app/routes/search_code.js
+++ b/app/routes/search_code.js
@@ -1,8 +1,6 @@
 import AuthorizeRoute from './authorize';
 
 export default AuthorizeRoute.extend({
-  previousPath: null,
-
   queryParams: {
     backToNewItem: false
   },
@@ -11,18 +9,8 @@ export default AuthorizeRoute.extend({
     return this.store.query('code', { stock: true });
   },
 
-  beforeModel() {
-    this._super(...arguments);
-    let previousRoutes = this.router.router.currentHandlerInfos;
-    let previousRoute = previousRoutes && previousRoutes.pop();
-    let path = previousRoute && previousRoute.name;
-    this.set("previousPath", path);
-  },
-
   setupController(controller, model){
     this._super(controller, model);
-    let previousPath = this.get('previousPath');
     controller.set('searchText', "");
-    controller.set("previousPath", previousPath);
   }
 });

--- a/app/routes/search_code.js
+++ b/app/routes/search_code.js
@@ -11,7 +11,7 @@ export default AuthorizeRoute.extend({
     return this.store.query('code', { stock: true });
   },
 
-  beforeModel(transition) {
+  beforeModel() {
     this._super(...arguments);
     let previousRoutes = this.router.router.currentHandlerInfos;
     let previousRoute = previousRoutes && previousRoutes.pop();

--- a/app/routes/search_code.js
+++ b/app/routes/search_code.js
@@ -1,6 +1,7 @@
 import AuthorizeRoute from './authorize';
 
 export default AuthorizeRoute.extend({
+  previousPath: null,
 
   queryParams: {
     backToNewItem: false
@@ -10,8 +11,18 @@ export default AuthorizeRoute.extend({
     return this.store.query('code', { stock: true });
   },
 
+  beforeModel(transition) {
+    this._super(...arguments);
+    let previousRoutes = this.router.router.currentHandlerInfos;
+    let previousRoute = previousRoutes && previousRoutes.pop();
+    let path = previousRoute && previousRoute.name;
+    this.set("previousPath", path);
+  },
+
   setupController(controller, model){
     this._super(controller, model);
+    let previousPath = this.get('previousPath');
     controller.set('searchText', "");
+    controller.set("previousPath", previousPath);
   }
 });

--- a/app/styles/templates/items/_index.scss
+++ b/app/styles/templates/items/_index.scss
@@ -1,0 +1,7 @@
+.add_item_button {
+  padding: 10px !important;
+  border: 1.4px solid white;
+  color: white;
+  font-weight: 600;
+  margin-top: 20%;
+}

--- a/app/templates/app_menu_list.hbs
+++ b/app/templates/app_menu_list.hbs
@@ -29,7 +29,7 @@
         </li>
       {{/if}}
       <li class="menu-list">
-        {{#link-to 'search_code' (query-params backToNewItem=false) class='appointments-link menu-list-anchor'}}
+        {{#link-to 'search_code' (query-params backToNewItem=false) class='menu-list-anchor inventory'}}
           {{fa-icon 'plus-circle' size="lg"}}&nbsp;&nbsp;{{t "add_inventory_item"}}
         {{/link-to}}
       </li>

--- a/app/templates/app_menu_list.hbs
+++ b/app/templates/app_menu_list.hbs
@@ -1,8 +1,12 @@
 <nav class="tab-bar white_border_bottom">
   <section class="middle tab-bar-section">
-    <h1 class="title">
-      {{t 'menu'}}
-    </h1>
+    {{#if stockAppVersion}}
+      <h1> {{t 'version'}}{{stockAppVersion}}</h1>
+    {{else}}
+      <h1 class="title">
+        {{t 'menu'}}
+      </h1>
+    {{/if}}
   </section>
 </nav>
 
@@ -24,15 +28,20 @@
           {{/link-to}}
         </li>
       {{/if}}
+      <li class="menu-list">
+        {{#link-to 'search_code' (query-params backToNewItem=false) class='appointments-link menu-list-anchor'}}
+          {{fa-icon 'plus-circle' size="lg"}}&nbsp;&nbsp;{{t "add_inventory_item"}}
+        {{/link-to}}
+      </li>
       {{#if (is-or session.currentUser.canManageAppointments getCurrentUser.canManageAppointments)}}
         <li class="menu-list">
           {{#link-to 'appointments' class='appointments-link menu-list-anchor'}}
-            {{fa-icon 'calendar-alt' size="lg"}}&nbsp;&nbsp;Manage Appointment Quotas
+            {{fa-icon 'calendar-alt' size="lg"}}&nbsp;&nbsp;{{t 'manage_inventory'}}
           {{/link-to}}
         </li>
         <li class="menu-list">
           <a href="#" class="menu-list-anchor" {{action 'createOrder'}}>
-            {{fa-icon 'shopping-basket' size="lg"}}&nbsp;&nbsp;Create New Order
+            {{fa-icon 'shopping-basket' size="lg"}}&nbsp;&nbsp;{{t 'new_order'}}
           </a>
         </li>
       {{/if}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,12 +1,5 @@
 <section class="main-section start_page">
   <div class="row">
-    <div class="small-12 columns center-text">
-      {{#if stockAppVersion}}
-        <h1> {{t 'version'}}{{stockAppVersion}} </h1>
-      {{/if}}
-      {{#link-to 'search_code' (query-params backToNewItem=false)}}Add item to inventory{{/link-to}}
-    </div>
-
     {{#if session.currentUser.canViewDashboard}}
       <div class="small-12 columns summary recent_orders">
         <h2>Orders In Process</h2>

--- a/app/templates/items/index.hbs
+++ b/app/templates/items/index.hbs
@@ -44,7 +44,12 @@
           {{#if stockAppVersion}}
             <h1> {{t 'version'}}{{stockAppVersion}} </h1>
           {{/if}}
-          {{#link-to 'search_code' (query-params backToNewItem=false)}}Add item to inventory{{/link-to}}
+
+          <div class="small-6 small-offset-3 medium-offset-1 medium-10 large-8 large-offset-2 columns center-text add_item_button">
+            {{#link-to 'search_code' (query-params backToNewItem=false)}}
+                {{fa-icon 'plus-circle' size="lg"}}&nbsp;&nbsp;{{t "add_inventory_item"}}
+            {{/link-to}}
+          </div>
         </div>
       {{/if}}
     </div>

--- a/tests/acceptance/add-new-item-to-inventory-test.js
+++ b/tests/acceptance/add-new-item-to-inventory-test.js
@@ -8,7 +8,7 @@ import '../factories/code';
 import FactoryGuy from 'ember-data-factory-guy';
 import { mockFindAll } from 'ember-data-factory-guy';
 
-var App, location1, location2, designation, code;
+var App, location1, location2, designation, code, bookingType;
 
 module('Acceptance: Add item to inventory', {
   beforeEach: function() {
@@ -31,8 +31,10 @@ module('Acceptance: Add item to inventory', {
     location1 = FactoryGuy.make("location");
     location2 = FactoryGuy.make("location");
     designation = FactoryGuy.make("designation");
+    bookingType = FactoryGuy.make("booking_type");
     mockFindAll('designation').returns({json: {designations: [designation.toJSON({includeId: true})]}});
     mockFindAll('location').returns({json: {locations: [location2.toJSON({includeId: true})], meta: {search: location2.get('building').toString()}}});
+    mockFindAll("booking_type").returns({json: {booking_types: [bookingType.toJSON({includeId: true})]}});
     code = FactoryGuy.make("code", {location: location1});
     visit("/");
   },
@@ -86,7 +88,21 @@ test("Select custom location on create item screen instead of default location o
 });
 
 test("Check validation for 'Add item to inventory ' page''", function(assert) {
-  assert.expect(4);
+  assert.expect(6);
+  andThen(function() {
+    visit("/");
+  });
+
+  andThen(function () {
+    assert.equal(currentPath(), "index");
+    click($('.small-block-grid-5 li:last'));
+  });
+
+  andThen(function () {
+    assert.equal(currentPath(), "app_menu_list");
+    click($('.inventory'));
+  });
+
   andThen(function() {
     visit("/search_code");
   });
@@ -132,8 +148,6 @@ test("Check validation for 'Add item to inventory ' page''", function(assert) {
   });
 });
 
-
-
 test("Redirect to /search_code after clicking Add item to inventory and save redirects to items details page", function(assert) {
   assert.expect(15);
 
@@ -148,8 +162,12 @@ test("Redirect to /search_code after clicking Add item to inventory and save red
 
   andThen(function () {
     assert.equal(currentPath(), "index");
-    assert.equal($('.center-text a').length, 1);
-    click($('.center-text a'));
+    click($('.small-block-grid-5 li:last'));
+  });
+
+  andThen(function () {
+    assert.equal(currentPath(), "app_menu_list");
+    click($('.inventory'));
   });
   andThen(function() {
     assert.equal(currentPath(), "search_code");

--- a/tests/acceptance/appointment-quotas-test.js
+++ b/tests/acceptance/appointment-quotas-test.js
@@ -25,7 +25,7 @@ const userProfile = {
 };
 
 
-let App, mocks, presets, slots;
+let App, mocks, presets, slots, bookingType;
 module("Acceptance: Appointment Quotas", {
   beforeEach: function() {
     App = startApp({}, 2);
@@ -52,14 +52,25 @@ module("Acceptance: Appointment Quotas", {
 
     presets = _.range(1,8).map(day => FactoryGuy.make("appointment_slot_preset", { id: day, day }).toJSON({ includeId: true }));
     slots = _.range(1,4).map(n => FactoryGuy.make('appointment_slot', { id: n, timestamp: makeTimestamp(n), quota: 2 }).toJSON({ includeId: true }));
-
+    bookingType = FactoryGuy.make("booking_type");
     $.mockjaxSettings.matchInRegistrationOrder = false;
+    $.mockjax({url:"/api/v1/orders/summar*", responseText: {
+      "submitted":14,
+      "awaiting_dispatch":1,
+      "dispatching":1,
+      "processing":2,
+      "priority_submitted":14,
+      "priority_dispatching":1,
+      "priority_processing":2,
+      "priority_awaiting_dispatch":1
+    }});
 
     mockResource('auth/current_user_profil*', userProfile);
     mockResource('designation*', { designations: [] });
     mockResource('location*', { locations: [] });
     mockResource('appointment_slot_preset*', { appointment_slots: presets });
     mockResource('appointment_slot*', { appointment_slots: slots });
+    mockResource('booking_typ*', { booking_types: [bookingType.toJSON({includeId: true})] });
 
     visit("/");
 

--- a/tests/acceptance/dashboard-test.js
+++ b/tests/acceptance/dashboard-test.js
@@ -7,13 +7,14 @@ import '../factories/location';
 import FactoryGuy from 'ember-data-factory-guy';
 import { mockFindAll } from 'ember-data-factory-guy';
 
-var App, data, userData;
+var App, data, userData, bookingType;
 
 module('Acceptance: Dashboard', {
   beforeEach: function() {
     $.mockjax.clear();
     App = startApp({}, 2);
     var location = FactoryGuy.make("location");
+    bookingType = FactoryGuy.make("booking_type");
     var designations = _.range(1, 6).map(order => FactoryGuy.make("designation", {
                         id: order,
                         state: 'submitted',
@@ -95,6 +96,7 @@ module('Acceptance: Dashboard', {
       responseText:  {designations: designations}
     });
     mockFindAll('location').returns({json: {locations: [location.toJSON({includeId: true})]}});
+    mockFindAll("booking_type").returns({json: {booking_types: [bookingType.toJSON({includeId: true})]}});
 
     visit("/");
 

--- a/tests/acceptance/goodcity-request-test.js
+++ b/tests/acceptance/goodcity-request-test.js
@@ -17,11 +17,23 @@ module('Acceptance: Goodcity Request test', {
     App = startApp({}, 2);
     designation1 = FactoryGuy.make("designation", { state: "processing", detailType: "GoodCity", code: "GC-00001" });
     var location = FactoryGuy.make("location");
+    var bookingType = FactoryGuy.make("booking_type");
     code = FactoryGuy.make("code", { location: location });
     var data = {"user_profile": [{"id": 2,"first_name": "David", "last_name": "Dara51", "mobile": "61111111", "user_role_ids": [1]}], "users": [{"id": 2,"first_name": "David", "last_name": "Dara51", "mobile": "61111111"}], "roles": [{"id": 4, "name": "Supervisor"}], "user_roles": [{"id": 1, "user_id": 2, "role_id": 4}]};
     request = FactoryGuy.make("goodcity_request", { quantity: 1, designation: designation1, code: code });
     $.mockjax({url:"/api/v1/auth/current_user_profil*",
       responseText: data });
+
+    $.mockjax({url:"/api/v1/orders/summar*", responseText: {
+      "submitted":14,
+      "awaiting_dispatch":1,
+      "dispatching":1,
+      "processing":2,
+      "priority_submitted":14,
+      "priority_dispatching":1,
+      "priority_processing":2,
+      "priority_awaiting_dispatch":1
+    }});
 
     visit("/");
 
@@ -38,6 +50,7 @@ module('Acceptance: Goodcity Request test', {
       items: [],
       orders_packages: [], meta: {search: designation1.get('code').toString()}}});
     mockFindAll('orders_package').returns({ json: {orders_packages: []}});
+    mockFindAll("booking_type").returns({json: {booking_types: [bookingType.toJSON({includeId: true})]}});
     $.mockjax({url: '/api/v1/package_type*', type: 'GET', status: 200,responseText: {
         codes: [code.toJSON({includeId: true})]
       }

--- a/tests/acceptance/item-inline-edit-test.js
+++ b/tests/acceptance/item-inline-edit-test.js
@@ -15,6 +15,7 @@ module('Acceptance: Item inline edit', {
     App = startApp({}, 2);
     var location = FactoryGuy.make("location");
     var designation = FactoryGuy.make("designation");
+    var bookingType = FactoryGuy.make("booking_type");
     pkg = FactoryGuy.make("item", { id: 50, state: "submitted" , quantity: 1, height: 10, width: 15, length: 20, notes: "Inline edit test" });
     mockFindAll('designation').returns({json: {designations: [designation.toJSON({includeId: true})]}});
     mockFindAll('location').returns({json: {locations: [location.toJSON({includeId: true})]}});
@@ -24,9 +25,22 @@ module('Acceptance: Item inline edit', {
     });
     var data = {"user_profile": [{"id": 2,"first_name": "David", "last_name": "Dara51", "mobile": "61111111", "user_role_ids": [1]}], "users": [{"id": 2,"first_name": "David", "last_name": "Dara51", "mobile": "61111111"}], "roles": [{"id": 4, "name": "Supervisor"}], "user_roles": [{"id": 1, "user_id": 2, "role_id": 4}]};
 
+    $.mockjax({url:"/api/v1/orders/summar*", responseText: {
+      "submitted":14,
+      "awaiting_dispatch":1,
+      "dispatching":1,
+      "processing":2,
+      "priority_submitted":14,
+      "priority_dispatching":1,
+      "priority_processing":2,
+      "priority_awaiting_dispatch":1
+    }});
+
     $.mockjax({url:"/api/v1/auth/current_user_profil*",
       responseText: data });
     mockFindAll('item').returns({ json: {items: [pkg.toJSON({includeId: true})]}});
+    mockFindAll("booking_type").returns({json: {booking_types: [bookingType.toJSON({includeId: true})]}});
+
     visit("/");
     andThen(function() {
       visit("/items");

--- a/tests/acceptance/login-test.js
+++ b/tests/acceptance/login-test.js
@@ -7,7 +7,7 @@ import '../factories/location';
 import FactoryGuy from 'ember-data-factory-guy';
 import { mockFindAll } from 'ember-data-factory-guy';
 
-var App, hk_user, non_hk_user, data;
+var App, hk_user, non_hk_user, data, bookingType;
 
 module('Acceptance: Login', {
   beforeEach: function() {
@@ -15,12 +15,14 @@ module('Acceptance: Login', {
 
     var location = FactoryGuy.make("location");
     var designation = FactoryGuy.make("designation");
+    bookingType = FactoryGuy.make("booking_type");
     mockFindAll('designation').returns({json: {designations: [designation.toJSON({includeId: true})]}});
     mockFindAll('location').returns({json: {locations: [location.toJSON({includeId: true})]}});
     data = {"user_profile": [{"id": 3,"first_name": "David", "last_name": "Dara51", "mobile": "61111112", "user_role_ids": [2]}], "users": [{"id": 3,"first_name": "David", "last_name": "Dara51", "mobile": "61111112"}], "roles": [{"id": 5, "name": "Supervisor"}], "user_roles": [{"id": 2, "user_id": 3, "role_id": 5}]};
 
     $.mockjax({url:"/api/v1/auth/current_user_profil*",
       responseText: data });
+    mockFindAll("booking_type").returns({json: {booking_types: [bookingType.toJSON({includeId: true})]}});
 
     hk_user = FactoryGuy.make('with_hk_mobile');
     non_hk_user = FactoryGuy.make('with_non_hk_mobile');
@@ -69,6 +71,17 @@ test("User is able to enter sms code and confirm and redirected to Home page and
 
   $.mockjax({url:"/api/v1/auth/verif*",responseText:{
     "jwt_token" : "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjo3LCJpYXQiOjE1MjU5MjQ0NzYsImlzcyI6Ikdvb2RDaXR5SEsiLCJleHAiOjEzNTI1OTI0NDc2fQ.lO6AdJtFrhOI9VaGRR55Wq-YWmeNoLagZthsIW39b2k"
+  }});
+
+  $.mockjax({url:"/api/v1/orders/summar*", responseText: {
+    "submitted":14,
+    "awaiting_dispatch":1,
+    "dispatching":1,
+    "processing":2,
+    "priority_submitted":14,
+    "priority_dispatching":1,
+    "priority_processing":2,
+    "priority_awaiting_dispatch":1
   }});
 
   var authToken = '"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjo2LCJpYXQiOjE1MTg3NzI4MjcsImlzcyI6Ikdvb2RDaXR5SEsiLCJleHAiOjE1MTk5ODI0Mjd9.WdsVvss9khm81WNScV5r6DiIwo8CQfHM1c4ON2IACes"';

--- a/tests/acceptance/order-details-appointment-info-test.js
+++ b/tests/acceptance/order-details-appointment-info-test.js
@@ -73,6 +73,16 @@ module("Acceptance: Order details, appointment info", {
     };
 
     $.mockjaxSettings.matchInRegistrationOrder = false;
+    $.mockjax({url:"/api/v1/orders/summar*", responseText: {
+      "submitted":14,
+      "awaiting_dispatch":1,
+      "dispatching":1,
+      "processing":2,
+      "priority_submitted":14,
+      "priority_dispatching":1,
+      "priority_processing":2,
+      "priority_awaiting_dispatch":1
+    }});
 
     mockResource('auth/current_user_profil*', userProfile);
     mockResource('booking_type*', { booking_types: _.values(BOOKING_TYPES) });

--- a/tests/acceptance/order-organisation-and-contact-test.js
+++ b/tests/acceptance/order-organisation-and-contact-test.js
@@ -11,7 +11,7 @@ import '../factories/organisations_user';
 import FactoryGuy from 'ember-data-factory-guy';
 import { mockFindAll } from 'ember-data-factory-guy';
 
-var App, designation, item1, orders_package1, gc_organisation, user, organisation_user;
+var App, designation, item1, orders_package1, gc_organisation, user, organisation_user, bookingType, data;
 
 module('Acceptance: Order summary', {
   beforeEach: function() {
@@ -19,17 +19,28 @@ module('Acceptance: Order summary', {
     user = FactoryGuy.make("user", { mobile: "123456", email: "abc@xyz" });
     var location = FactoryGuy.make("location");
     gc_organisation = FactoryGuy.make("gc_organisation");
+    bookingType = FactoryGuy.make("booking_type");
     organisation_user = FactoryGuy.make("organisationsUser", { gcOrganisation: gc_organisation, user: user });
     designation = FactoryGuy.make("designation", { state: "submitted", detailType: "GoodCity", gcOrganisation: gc_organisation, createdBy: user });
     item1 = FactoryGuy.make("item", { state: "submitted", quantity: 0 , designation: designation});
     orders_package1 = FactoryGuy.make("orders_package", { state: "dispatched", quantity: 1, item: item1, designation: designation });
-    var data = {"user_profile": [{"id": 2,"first_name": "David", "last_name": "Dara51", "mobile": "61111111", "user_role_ids": [1]}], "users": [{"id": 2,"first_name": "David", "last_name": "Dara51", "mobile": "61111111"}], "roles": [{"id": 4, "name": "Supervisor"}], "user_roles": [{"id": 1, "user_id": 2, "role_id": 4}]};
+    data = {"user_profile": [{"id": 2,"first_name": "David", "last_name": "Dara51", "mobile": "61111111", "user_role_ids": [1]}], "users": [{"id": 2,"first_name": "David", "last_name": "Dara51", "mobile": "61111111"}], "roles": [{"id": 4, "name": "Supervisor"}], "user_roles": [{"id": 1, "user_id": 2, "role_id": 4}]};
 
     $.mockjax({url:"/api/v1/auth/current_user_profil*",
       responseText: data });
     $.mockjax({url: "/api/v1/designations/*", type: 'GET', status: 200,responseText: {
       designations: [designation.toJSON({includeId: true})],
       orders_packages: [orders_package1.toJSON({includeId: true})]
+    }});
+    $.mockjax({url:"/api/v1/orders/summar*", responseText: {
+      "submitted":14,
+      "awaiting_dispatch":1,
+      "dispatching":1,
+      "processing":2,
+      "priority_submitted":14,
+      "priority_dispatching":1,
+      "priority_processing":2,
+      "priority_awaiting_dispatch":1
     }});
 
     visit("/");
@@ -45,6 +56,8 @@ module('Acceptance: Order summary', {
     mockFindAll('location').returns({json: {locations: [location.toJSON({includeId: true})]}});
     mockFindAll('designation').returns({ json: {designations: [designation.toJSON({includeId: true})], items: [item1.toJSON({includeId: true})], orders_packages: [orders_package1.toJSON({includeId: true})], meta: {search: designation.get('code').toString()}}});
     mockFindAll('orders_package').returns({ json: {orders_packages: [orders_package1.toJSON({includeId: true})]}});
+    mockFindAll('booking_type').returns({ json: {booking_types: [bookingType.toJSON({includeId: true})]}});
+
   },
   afterEach: function() {
     Ember.run(App, 'destroy');

--- a/tests/acceptance/order-redispatch-test.js
+++ b/tests/acceptance/order-redispatch-test.js
@@ -18,6 +18,7 @@ module('Acceptance: Order redispatch', {
     order6 = FactoryGuy.make("designation", { state: "dispatching", detailType: "GoodCity", code: "GC-00005" });
     order7 = FactoryGuy.make("designation", { state: "awaiting_dispatch", detailType: "GoodCity", code: "GC-00005" });
     var location = FactoryGuy.make("location");
+    var bookingType = FactoryGuy.make("booking_type");
     item = FactoryGuy.make("item", { state: "submitted" , quantity: 1, designation: order6});
     item1 = FactoryGuy.make("item", { state: "submitted", quantity: 1 , designation: order6});
     item2 = FactoryGuy.make("item", { state: "submitted" , quantity: 1, designation: order7});
@@ -31,6 +32,17 @@ module('Acceptance: Order redispatch', {
     $.mockjax({url:"/api/v1/auth/current_user_profil*",
       responseText: data });
 
+    $.mockjax({url:"/api/v1/orders/summar*", responseText: {
+      "submitted":14,
+      "awaiting_dispatch":1,
+      "dispatching":1,
+      "processing":2,
+      "priority_submitted":14,
+      "priority_dispatching":1,
+      "priority_processing":2,
+      "priority_awaiting_dispatch":1
+    }});
+
     visit("/");
 
     andThen(function() {
@@ -42,6 +54,8 @@ module('Acceptance: Order redispatch', {
       items: [item.toJSON({includeId: true}), item1.toJSON({includeId: true}), item2.toJSON({includeId: true}), item3.toJSON({includeId: true})],
       orders_packages: [orders_package.toJSON({includeId: true}), orders_package1.toJSON({includeId: true}), orders_package2.toJSON({includeId: true}), orders_package3.toJSON({includeId: true})], meta: {search: order6.get('code').toString()}}});
     mockFindAll('orders_package').returns({ json: {orders_packages: [orders_package.toJSON({includeId: true}), orders_package1.toJSON({includeId: true}), orders_package2.toJSON({includeId: true}), orders_package3.toJSON({includeId: true})]}});
+    mockFindAll("booking_type").returns({json: {booking_types: [bookingType.toJSON({includeId: true})]}});
+
   },
   afterEach: function() {
     Ember.run(App, 'destroy');

--- a/tests/acceptance/order-restart-processing-test.js
+++ b/tests/acceptance/order-restart-processing-test.js
@@ -18,6 +18,7 @@ module('Acceptance: Order restart processing', {
     order6 = FactoryGuy.make("designation", { state: "awaiting_dispatch", detailType: "GoodCity", code: "GC-00005" });
     order7 = FactoryGuy.make("designation", { state: "processing", detailType: "GoodCity", code: "GC-00005" });
     var location = FactoryGuy.make("location");
+    var bookingType = FactoryGuy.make("booking_type");
     item = FactoryGuy.make("item", { state: "submitted" , quantity: 1, designation: order6});
     item1 = FactoryGuy.make("item", { state: "submitted", quantity: 1 , designation: order6});
     item2 = FactoryGuy.make("item", { state: "submitted" , quantity: 1, designation: order7});
@@ -31,6 +32,17 @@ module('Acceptance: Order restart processing', {
     $.mockjax({url:"/api/v1/auth/current_user_profil*",
       responseText: data });
 
+    $.mockjax({url:"/api/v1/orders/summar*", responseText: {
+      "submitted":14,
+      "awaiting_dispatch":1,
+      "dispatching":1,
+      "processing":2,
+      "priority_submitted":14,
+      "priority_dispatching":1,
+      "priority_processing":2,
+      "priority_awaiting_dispatch":1
+    }});
+
     visit("/");
 
     andThen(function() {
@@ -42,6 +54,8 @@ module('Acceptance: Order restart processing', {
       items: [item.toJSON({includeId: true}), item1.toJSON({includeId: true}), item2.toJSON({includeId: true}), item3.toJSON({includeId: true})],
       orders_packages: [orders_package.toJSON({includeId: true}), orders_package1.toJSON({includeId: true}), orders_package2.toJSON({includeId: true}), orders_package3.toJSON({includeId: true})], meta: {search: order6.get('code').toString()}}});
     mockFindAll('orders_package').returns({ json: {orders_packages: [orders_package.toJSON({includeId: true}), orders_package1.toJSON({includeId: true}), orders_package2.toJSON({includeId: true}), orders_package3.toJSON({includeId: true})]}});
+    mockFindAll("booking_type").returns({json: {booking_types: [bookingType.toJSON({includeId: true})]}});
+
   },
   afterEach: function() {
     Ember.run(App, 'destroy');

--- a/tests/acceptance/order-resubmit-cancel-test.js
+++ b/tests/acceptance/order-resubmit-cancel-test.js
@@ -18,6 +18,7 @@ module('Acceptance: Order resubmit', {
     order6 = FactoryGuy.make("designation", { state: "cancelled", detailType: "GoodCity", code: "GC-00005" });
     order7 = FactoryGuy.make("designation", { state: "submitted", detailType: "GoodCity", code: "GC-00005" });
     var location = FactoryGuy.make("location");
+    var bookingType = FactoryGuy.make("booking_type");
     item = FactoryGuy.make("item", { state: "submitted" , quantity: 1, designation: order6});
     item1 = FactoryGuy.make("item", { state: "submitted", quantity: 1 , designation: order6});
     item2 = FactoryGuy.make("item", { state: "submitted" , quantity: 1, designation: order7});
@@ -31,6 +32,17 @@ module('Acceptance: Order resubmit', {
     $.mockjax({url:"/api/v1/auth/current_user_profil*",
       responseText: data });
 
+    $.mockjax({url:"/api/v1/orders/summar*", responseText: {
+      "submitted":14,
+      "awaiting_dispatch":1,
+      "dispatching":1,
+      "processing":2,
+      "priority_submitted":14,
+      "priority_dispatching":1,
+      "priority_processing":2,
+      "priority_awaiting_dispatch":1
+    }});
+
     visit("/");
 
     andThen(function() {
@@ -42,6 +54,8 @@ module('Acceptance: Order resubmit', {
       items: [item.toJSON({includeId: true}), item1.toJSON({includeId: true}), item2.toJSON({includeId: true}), item3.toJSON({includeId: true})],
       orders_packages: [orders_package.toJSON({includeId: true}), orders_package1.toJSON({includeId: true}), orders_package2.toJSON({includeId: true}), orders_package3.toJSON({includeId: true})], meta: {search: order6.get('code').toString()}}});
     mockFindAll('orders_package').returns({ json: {orders_packages: [orders_package.toJSON({includeId: true}), orders_package1.toJSON({includeId: true}), orders_package2.toJSON({includeId: true}), orders_package3.toJSON({includeId: true})]}});
+    mockFindAll("booking_type").returns({json: {booking_types: [bookingType.toJSON({includeId: true})]}});
+
   },
   afterEach: function() {
     Ember.run(App, 'destroy');

--- a/tests/acceptance/order-search-list-test.js
+++ b/tests/acceptance/order-search-list-test.js
@@ -6,17 +6,19 @@ import "../factories/designation";
 import "../factories/item";
 import FactoryGuy, { mockFindAll } from "ember-data-factory-guy";
 
-var App, designation, item, orders_package, user;
+var App, designation, item, orders_package, user, bookingType;
 var mocks;
 
 module("Acceptance: Order search list", {
   beforeEach: function() {
     App = startApp({}, 2);
     user = FactoryGuy.make("user", { mobile: "123456", email: "abc@xyz", firstName: "John", lastName: "Lennon", id: 5 });
-    designation = FactoryGuy.make("designation", { 
+    designation = FactoryGuy.make("designation", {
       detailType: 'GoodCity'
     });
     item = FactoryGuy.make("item", { state: "submitted" });
+    var location = FactoryGuy.make("location");
+    bookingType = FactoryGuy.make("booking_type");
     orders_package = FactoryGuy.make("orders_package", {
       state: "designated",
       item: item,
@@ -57,7 +59,17 @@ module("Acceptance: Order search list", {
           meta: { search: designation.get("code") },
           designation: designation.toJSON({ includeId: true })
         }
-      })
+      }),
+      $.mockjax({url:"/api/v1/orders/summar*", responseText: {
+        "submitted":14,
+        "awaiting_dispatch":1,
+        "dispatching":1,
+        "processing":2,
+        "priority_submitted":14,
+        "priority_dispatching":1,
+        "priority_processing":2,
+        "priority_awaiting_dispatch":1
+      }})
     );
 
     mockFindAll('designation').returns({ json: {
@@ -66,8 +78,10 @@ module("Acceptance: Order search list", {
       orders_packages: [orders_package.toJSON({ includeId: true })],
       meta: { search: designation.get("code") }
     }});
-    
+
     mockFindAll('orders_package').returns({ json: {orders_packages: [orders_package.toJSON({includeId: true})]}});
+    mockFindAll('location').returns({json: {locations: [location.toJSON({includeId: true})]}});
+    mockFindAll("booking_type").returns({json: {booking_types: [bookingType.toJSON({includeId: true})]}});
 
 
     visit("/");
@@ -129,8 +143,8 @@ test("Order codes should be displayed on screen", function(assert) {
 
   andThen(function() {
     assert.equal(
-      find(".order_code").text().trim(), 
-      designation.get("code"), 
+      find(".order_code").text().trim(),
+      designation.get("code"),
       "Should be displaying the order code"
     );
   });
@@ -144,8 +158,8 @@ test("Order's state should be displayed on screen", function(assert) {
 
   andThen(function() {
     assert.equal(
-      find(".order_state_text").text().trim().toLowerCase(), 
-      designation.get("state"), 
+      find(".order_state_text").text().trim().toLowerCase(),
+      designation.get("state"),
       "Should be displaying the order's state"
     );
   });

--- a/tests/acceptance/order-state-awaiting-dispatch-test.js
+++ b/tests/acceptance/order-state-awaiting-dispatch-test.js
@@ -10,7 +10,7 @@ import { mockFindAll } from 'ember-data-factory-guy';
 
 var App, designation1, designation2, item, item1,
     orders_package, orders_package1, orders_package2, orders_package3,
-    item2, item3;
+    item2, item3, bookingType;
 
 module('Acceptance: Order State awaiting dispatch', {
   beforeEach: function() {
@@ -18,6 +18,7 @@ module('Acceptance: Order State awaiting dispatch', {
     designation1 = FactoryGuy.make("designation", { state: "processing", detailType: "GoodCity", code: "GC-00001" });
     designation2 = FactoryGuy.make("designation", { state: "awaiting dispatch", detailType: "GoodCity", code: "GC-00001" });
     var location = FactoryGuy.make("location");
+    bookingType = FactoryGuy.make("booking_type");
     item = FactoryGuy.make("item", { state: "submitted" , quantity: 1, designation: designation1});
     item1 = FactoryGuy.make("item", { state: "submitted", quantity: 1 , designation: designation1});
     item2 = FactoryGuy.make("item", { state: "submitted" , quantity: 1, designation: designation2});
@@ -31,6 +32,17 @@ module('Acceptance: Order State awaiting dispatch', {
     $.mockjax({url:"/api/v1/auth/current_user_profil*",
       responseText: data });
 
+    $.mockjax({url:"/api/v1/orders/summar*", responseText: {
+      "submitted":14,
+      "awaiting_dispatch":1,
+      "dispatching":1,
+      "processing":2,
+      "priority_submitted":14,
+      "priority_dispatching":1,
+      "priority_processing":2,
+      "priority_awaiting_dispatch":1
+    }});
+
     visit("/");
 
     andThen(function() {
@@ -42,6 +54,7 @@ module('Acceptance: Order State awaiting dispatch', {
       items: [item.toJSON({includeId: true}), item1.toJSON({includeId: true}), item2.toJSON({includeId: true}), item3.toJSON({includeId: true})],
       orders_packages: [orders_package.toJSON({includeId: true}), orders_package1.toJSON({includeId: true}), orders_package2.toJSON({includeId: true}), orders_package3.toJSON({includeId: true})], meta: {search: designation1.get('code').toString()}}});
     mockFindAll('orders_package').returns({ json: {orders_packages: [orders_package.toJSON({includeId: true}), orders_package1.toJSON({includeId: true}), orders_package2.toJSON({includeId: true}), orders_package3.toJSON({includeId: true})]}});
+    mockFindAll('booking_type').returns({ json: {booking_types: [bookingType.toJSON({includeId: true})]}});
   },
   afterEach: function() {
     Ember.run(App, 'destroy');

--- a/tests/acceptance/order-state-cancelled-test.js
+++ b/tests/acceptance/order-state-cancelled-test.js
@@ -18,6 +18,7 @@ module('Acceptance: Order State cancelled', {
     order5 = FactoryGuy.make("designation", { state: "dispatching", detailType: "GoodCity", code: "GC-00001" });
     order6 = FactoryGuy.make("designation", { state: "cancelled", detailType: "GoodCity", code: "GC-00001" });
     var location = FactoryGuy.make("location");
+    var bookingType = FactoryGuy.make("booking_type");
     item = FactoryGuy.make("item", { state: "submitted" , quantity: 1, designation: order5});
     item1 = FactoryGuy.make("item", { state: "submitted", quantity: 1 , designation: order5});
     item2 = FactoryGuy.make("item", { state: "submitted" , quantity: 1, designation: order6});
@@ -31,6 +32,17 @@ module('Acceptance: Order State cancelled', {
     $.mockjax({url:"/api/v1/auth/current_user_profil*",
       responseText: data });
 
+    $.mockjax({url:"/api/v1/orders/summar*", responseText: {
+      "submitted":14,
+      "awaiting_dispatch":1,
+      "dispatching":1,
+      "processing":2,
+      "priority_submitted":14,
+      "priority_dispatching":1,
+      "priority_processing":2,
+      "priority_awaiting_dispatch":1
+    }});
+
     visit("/");
 
     andThen(function() {
@@ -42,6 +54,8 @@ module('Acceptance: Order State cancelled', {
       items: [item.toJSON({includeId: true}), item1.toJSON({includeId: true}), item2.toJSON({includeId: true}), item3.toJSON({includeId: true})],
       orders_packages: [orders_package.toJSON({includeId: true}), orders_package1.toJSON({includeId: true}), orders_package2.toJSON({includeId: true}), orders_package3.toJSON({includeId: true})], meta: {search: order5.get('code').toString()}}});
     mockFindAll('orders_package').returns({ json: {orders_packages: [orders_package.toJSON({includeId: true}), orders_package1.toJSON({includeId: true}), orders_package2.toJSON({includeId: true}), orders_package3.toJSON({includeId: true})]}});
+    mockFindAll('booking_type').returns({ json: {booking_types: [bookingType.toJSON({includeId: true})]}});
+
   },
   afterEach: function() {
     Ember.run(App, 'destroy');

--- a/tests/acceptance/order-state-close-test.js
+++ b/tests/acceptance/order-state-close-test.js
@@ -18,6 +18,7 @@ module('Acceptance: Order State closed', {
     order3 = FactoryGuy.make("designation", { state: "dispatching", detailType: "GoodCity", code: "GC-00001" });
     order4 = FactoryGuy.make("designation", { state: "closed", detailType: "GoodCity", code: "GC-00001" });
     var location = FactoryGuy.make("location");
+    var bookingType = FactoryGuy.make("booking_type");
     item = FactoryGuy.make("item", { state: "submitted" , quantity: 1, designation: order3});
     item1 = FactoryGuy.make("item", { state: "submitted", quantity: 1 , designation: order3});
     item2 = FactoryGuy.make("item", { state: "submitted" , quantity: 1, designation: order4});
@@ -31,6 +32,17 @@ module('Acceptance: Order State closed', {
     $.mockjax({url:"/api/v1/auth/current_user_profil*",
       responseText: data });
 
+    $.mockjax({url:"/api/v1/orders/summar*", responseText: {
+      "submitted":14,
+      "awaiting_dispatch":1,
+      "dispatching":1,
+      "processing":2,
+      "priority_submitted":14,
+      "priority_dispatching":1,
+      "priority_processing":2,
+      "priority_awaiting_dispatch":1
+    }});
+
     visit("/");
 
     andThen(function() {
@@ -42,6 +54,8 @@ module('Acceptance: Order State closed', {
       items: [item.toJSON({includeId: true}), item1.toJSON({includeId: true}), item2.toJSON({includeId: true}), item3.toJSON({includeId: true})],
       orders_packages: [orders_package.toJSON({includeId: true}), orders_package1.toJSON({includeId: true}), orders_package2.toJSON({includeId: true}), orders_package3.toJSON({includeId: true})], meta: {search: order3.get('code').toString()}}});
     mockFindAll('orders_package').returns({ json: {orders_packages: [orders_package.toJSON({includeId: true}), orders_package1.toJSON({includeId: true}), orders_package2.toJSON({includeId: true}), orders_package3.toJSON({includeId: true})]}});
+    mockFindAll('booking_type').returns({ json: {booking_types: [bookingType.toJSON({includeId: true})]}});
+
   },
   afterEach: function() {
     Ember.run(App, 'destroy');

--- a/tests/acceptance/order-state-dispatching-test.js
+++ b/tests/acceptance/order-state-dispatching-test.js
@@ -18,6 +18,7 @@ module('Acceptance: Order State dispatching', {
     designation1 = FactoryGuy.make("designation", { state: "awaiting dispatch", detailType: "GoodCity", code: "GC-00001" });
     designation2 = FactoryGuy.make("designation", { state: "dispatching", detailType: "GoodCity", code: "GC-00001" });
     var location = FactoryGuy.make("location");
+    var bookingType = FactoryGuy.make("booking_type");
     item = FactoryGuy.make("item", { state: "submitted" , quantity: 1, designation: designation1});
     item1 = FactoryGuy.make("item", { state: "submitted", quantity: 1 , designation: designation1});
     item2 = FactoryGuy.make("item", { state: "submitted" , quantity: 1, designation: designation2});
@@ -31,6 +32,17 @@ module('Acceptance: Order State dispatching', {
     $.mockjax({url:"/api/v1/auth/current_user_profil*",
       responseText: data });
 
+    $.mockjax({url:"/api/v1/orders/summar*", responseText: {
+      "submitted":14,
+      "awaiting_dispatch":1,
+      "dispatching":1,
+      "processing":2,
+      "priority_submitted":14,
+      "priority_dispatching":1,
+      "priority_processing":2,
+      "priority_awaiting_dispatch":1
+    }});
+
     visit("/");
 
     andThen(function() {
@@ -42,6 +54,8 @@ module('Acceptance: Order State dispatching', {
       items: [item.toJSON({includeId: true}), item1.toJSON({includeId: true}), item2.toJSON({includeId: true}), item3.toJSON({includeId: true})],
       orders_packages: [orders_package.toJSON({includeId: true}), orders_package1.toJSON({includeId: true}), orders_package2.toJSON({includeId: true}), orders_package3.toJSON({includeId: true})], meta: {search: designation1.get('code').toString()}}});
     mockFindAll('orders_package').returns({ json: {orders_packages: [orders_package.toJSON({includeId: true}), orders_package1.toJSON({includeId: true}), orders_package2.toJSON({includeId: true}), orders_package3.toJSON({includeId: true})]}});
+    mockFindAll('booking_type').returns({ json: {booking_types: [bookingType.toJSON({includeId: true})]}});
+
   },
   afterEach: function() {
     Ember.run(App, 'destroy');

--- a/tests/acceptance/order-state-processing-test.js
+++ b/tests/acceptance/order-state-processing-test.js
@@ -18,6 +18,7 @@ module('Acceptance: Order State processing', {
     designation1 = FactoryGuy.make("designation", { state: "submitted", detailType: "GoodCity", code: "GC-00002" });
     designation2 = FactoryGuy.make("designation", { state: "processing", detailType: "GoodCity", code: "GC-00002" });
     var location = FactoryGuy.make("location");
+    var bookingType = FactoryGuy.make("booking_type");
     item = FactoryGuy.make("item", { state: "submitted" , quantity: 1, designation: designation1});
     item1 = FactoryGuy.make("item", { state: "submitted", quantity: 1 , designation: designation1});
     item2 = FactoryGuy.make("item", { state: "submitted" , quantity: 1, designation: designation2});
@@ -31,6 +32,17 @@ module('Acceptance: Order State processing', {
     $.mockjax({url:"/api/v1/auth/current_user_profil*",
       responseText: data });
 
+    $.mockjax({url:"/api/v1/orders/summar*", responseText: {
+      "submitted":14,
+      "awaiting_dispatch":1,
+      "dispatching":1,
+      "processing":2,
+      "priority_submitted":14,
+      "priority_dispatching":1,
+      "priority_processing":2,
+      "priority_awaiting_dispatch":1
+    }});
+
     visit("/");
 
     andThen(function() {
@@ -42,6 +54,8 @@ module('Acceptance: Order State processing', {
       items: [item.toJSON({includeId: true}), item1.toJSON({includeId: true}), item2.toJSON({includeId: true}), item3.toJSON({includeId: true})],
       orders_packages: [orders_package.toJSON({includeId: true}), orders_package1.toJSON({includeId: true}), orders_package2.toJSON({includeId: true}), orders_package3.toJSON({includeId: true})], meta: {search: designation1.get('code').toString()}}});
     mockFindAll('orders_package').returns({ json: {orders_packages: [orders_package.toJSON({includeId: true}), orders_package1.toJSON({includeId: true}), orders_package2.toJSON({includeId: true}), orders_package3.toJSON({includeId: true})]}});
+    mockFindAll('booking_type').returns({ json: {booking_types: [bookingType.toJSON({includeId: true})]}});
+
   },
   afterEach: function() {
     Ember.run(App, 'destroy');

--- a/tests/acceptance/partial-undesignate-test.js
+++ b/tests/acceptance/partial-undesignate-test.js
@@ -14,12 +14,19 @@ module('Acceptance: Partial undesignate/modify', {
   beforeEach: function() {
     App = startApp({}, 2);
     var location = FactoryGuy.make("location");
+    var bookingType = FactoryGuy.make("booking_type");
     mockFindAll('location').returns({json: {locations: [location.toJSON({includeId: true})]}});
+    mockFindAll('booking_type').returns({json: {booking_types: [bookingType.toJSON({includeId: true})]}});
     order1 = FactoryGuy.make("designation", { id: 100, state: "submitted" });
     pkg1 = FactoryGuy.make("item", { id: 51, state: "submitted" , designation: order1, quantity: 0});
     pkg2 = FactoryGuy.make("item", { id: 52, state: "submitted", quantity: 1, receivedQuantity: 1 });
     orders_pkg1 = FactoryGuy.make("orders_package", { id: 500, state: "designated", quantity: 1, item: pkg1, designationId: order1.id, designation: order1 });
     orders_pkg2 = FactoryGuy.make("orders_package", { id: 501, state: "dispatched", quantity: 1, item: pkg1, designationId: order1.id, designation: order1, sent_on: Date.now() });
+
+    var data = {"user_profile": [{"id": 2,"first_name": "David", "last_name": "Dara51", "mobile": "61111111", "user_role_ids": [1]}], "users": [{"id": 2,"first_name": "David", "last_name": "Dara51", "mobile": "61111111"}], "roles": [{"id": 4, "name": "Supervisor"}], "user_roles": [{"id": 1, "user_id": 2, "role_id": 4}]};
+
+    $.mockjax({url:"/api/v1/auth/current_user_profil*",
+      responseText: data });
   },
   afterEach: function() {
     Ember.run(App, 'destroy');

--- a/tests/acceptance/purpose-test.js
+++ b/tests/acceptance/purpose-test.js
@@ -8,13 +8,14 @@ import '../factories/designation';
 import '../factories/item';
 import FactoryGuy from 'ember-data-factory-guy';
 
-var App, designation, item, orders_package, orders_purpose, purpose;
+var App, designation, item, orders_package, orders_purpose, purpose, bookingType;
 
 module('Acceptance: Order Detail', {
   beforeEach: function() {
     App = startApp({}, 2);
     designation = FactoryGuy.make("designation", { detailType: "GoodCity", code:"GC-00001" });
     purpose = FactoryGuy.make("purpose", { nameEn: "Organisation" });
+    bookingType = FactoryGuy.make("booking_type");
     orders_purpose = FactoryGuy.make("orders_purpose", { designationId: designation.id, purposeId: purpose.id, designation: designation, purpose: purpose });
     item = FactoryGuy.make("item", { state: "submitted" , designation: designation});
     orders_package = FactoryGuy.make("orders_package", { state: "designated", quantity: 6, item: item, designation: designation });
@@ -25,6 +26,7 @@ module('Acceptance: Order Detail', {
       responseText: data });
 
     $.mockjax({url: '/api/v1/designation*', type: 'GET', status: 200,responseText: designationData});
+    $.mockjax({url: '/api/v1/booking_ty*', type: 'GET', status: 200,responseText: { booking_types: [bookingType.toJSON({includeId: true})] }});
 
     visit("/orders/" + designation.id + '/purposes');
   },

--- a/tests/acceptance/split-quantity-of-items-test.js
+++ b/tests/acceptance/split-quantity-of-items-test.js
@@ -15,15 +15,27 @@ module('Acceptance: Split Item Quantity', {
     App = startApp({}, 2);
     var location = FactoryGuy.make("location");
     var designation = FactoryGuy.make("designation");
+    var bookingType = FactoryGuy.make("booking_type");
     mockFindAll('designation').returns({json: {designations: [designation.toJSON({includeId: true})]}});
     mockFindAll('location').returns({json: {locations: [location.toJSON({includeId: true})]}});
+    mockFindAll('booking_type').returns({json: {booking_types: [bookingType.toJSON({includeId: true})]}});
     pkg = FactoryGuy.make("item", { id: 50, state: "submitted" , quantity: 20, height: 10, width: 15, length: 20, notes: "Split quantity test." });
     var data = {"user_profile": [{"id": 2,"first_name": "David", "last_name": "Dara51", "mobile": "61111111", "user_role_ids": [1]}], "users": [{"id": 2,"first_name": "David", "last_name": "Dara51", "mobile": "61111111"}], "roles": [{"id": 4, "name": "Supervisor"}], "user_roles": [{"id": 1, "user_id": 2, "role_id": 4}]};
 
     mocks = [];
     $.mockjaxSettings.matchInRegistrationOrder = false;
     mocks.push(
-      $.mockjax({url:"/api/v1/auth/current_user_profil*", responseText: data })
+      $.mockjax({url:"/api/v1/auth/current_user_profil*", responseText: data }),
+      $.mockjax({url:"/api/v1/orders/summar*", responseText: {
+        "submitted":14,
+        "awaiting_dispatch":1,
+        "dispatching":1,
+        "processing":2,
+        "priority_submitted":14,
+        "priority_dispatching":1,
+        "priority_processing":2,
+        "priority_awaiting_dispatch":1
+      }})
     );
   },
   afterEach: function() {

--- a/tests/acceptance/supervisor-user-footer-test.js
+++ b/tests/acceptance/supervisor-user-footer-test.js
@@ -16,6 +16,7 @@ module('Acceptance: Supervisor footer', {
   beforeEach: function() {
     App = startApp({}, 2);
     var location = FactoryGuy.make("location");
+    var bookingType = FactoryGuy.make("booking_type");
     mockFindAll('location').returns({json: {locations: [location.toJSON({includeId: true})]}});
     designation = FactoryGuy.make("designation", { detailType: "GoodCity", code:"GC-00001" });
     purpose = FactoryGuy.make("purpose", { nameEn: "Organisation" });
@@ -24,9 +25,21 @@ module('Acceptance: Supervisor footer', {
     orders_package = FactoryGuy.make("orders_package", { state: "designated", quantity: 6, item: item, designation: designation });
     var data = {"user_profile": [{"id": 2,"first_name": "David", "last_name": "Dara51", "mobile": "61111111", "user_role_ids": [1]}], "users": [{"id": 2,"first_name": "David", "last_name": "Dara51", "mobile": "61111111"}], "roles": [{"id": 4, "name": "Supervisor"}], "user_roles": [{"id": 1, "user_id": 2, "role_id": 4}]};
     var designationData ={designations: [designation.toJSON({includeId: true})], items: [item.toJSON({includeId: true})], orders_purposes: [orders_purpose.toJSON({includeId:true})], purposes: [purpose.toJSON({includeId:true})]};
+    mockFindAll('booking_type').returns({json: {booking_types: [bookingType.toJSON({includeId: true})]}});
 
     $.mockjax({url:"/api/v1/auth/current_user_profil*",
       responseText: data });
+    $.mockjax({url:"/api/v1/orders/summar*", responseText: {
+      "submitted":14,
+      "awaiting_dispatch":1,
+      "dispatching":1,
+      "processing":2,
+      "priority_submitted":14,
+      "priority_dispatching":1,
+      "priority_processing":2,
+      "priority_awaiting_dispatch":1
+    }});
+
     visit("/");
 
     $.mockjax({url: '/api/v1/designation*', type: 'GET', status: 200,responseText: designationData});

--- a/tests/factories/booking_type.js
+++ b/tests/factories/booking_type.js
@@ -1,0 +1,14 @@
+import FactoryGuy from 'ember-data-factory-guy';
+
+FactoryGuy.define('booking_type',{
+  sequences: {
+    id: function(num) {
+      return num + 100;
+    },
+  },
+  default: {
+    id:        FactoryGuy.generate('id'),
+    nameEn:   'appointment'
+  },
+});
+export default {};


### PR DESCRIPTION
Hi Team,
This is PR for JIRA ticket GCW-2361-Move app version and item create from home screen.  This PR includes:
* `Add inventory Item` is moved from dashboard to Menu and Item page.
* App version is moved from dashboard to Menu top (and it is available only for mobile).
* Changed and fixed test cases accordingly.
* Fixed test cases error related to mocking of `/summary` and `/booking_type` `GET` resource.
Please review the PR and let me know if any change is required.
Thanks.