### PR TITLE
GCW-2366 logistics tab : Add rows

### DIFF
--- a/app/controllers/orders/order_types.js
+++ b/app/controllers/orders/order_types.js
@@ -1,3 +1,54 @@
 import detail from "./detail";
+import Ember  from 'ember';
+import _ from 'lodash';
 
-export default detail.extend();
+export default detail.extend({
+
+  logisticDataRows: Ember.computed('model', function () {
+    const order = this.get('model');
+    return [
+      // Schedule
+      {
+        label: this.get('i18n').t('order_details.logistics.scheduled'),
+        text: moment.tz(order.get('orderTransport.scheduledAt'), "Asia/Hong_Kong").format('dddd Do MMMM hh:mm a'),
+        action: 'openSchedulePopup',
+        icon: 'clock',
+        name: 'reschedule'
+      },
+      // Type
+      {
+        label: this.get('i18n').t('order_details.logistics.type'),
+        text: order.get('bookingTypeLabel'),
+        action: _.noop,
+        icon: 'tv',
+        name: 'type'
+      },
+      // Transport type
+      {
+        label: this.get('i18n').t('order_details.logistics.transport_type'),
+        text: order.get("orderTransport.transportType") === "self" ?
+          this.get('i18n').t('order_details.logistics.vehicle.self') :
+          this.get('i18n').t('order_details.logistics.vehicle.van'),
+        action: _.noop,
+        icon: 'file-invoice-dollar',
+        name: 'transport_type'
+      },
+      // District
+      {
+        label: this.get('i18n').t('order_details.logistics.destination'),
+        text: order.get("district.name"),
+        action: _.noop,
+        icon: '',
+        name: 'district'
+      },
+      // Vehicle
+      {
+        label: this.get('i18n').t('order_details.logistics.vehicle_type'),
+        text: order.get("orderTransport.gogovanTransport.name"),
+        action: _.noop,
+        icon: '',
+        name: 'vehicle'
+      }
+    ];
+  })
+});

--- a/app/locales/en/translations.coffee
+++ b/app/locales/en/translations.coffee
@@ -158,6 +158,19 @@ I18nTranslationsEn =
     "close_order_popup": "All items in this order are dispatched. Would you like to close the Order? You will not be able to modify the order after closing it."
     "cancel_item_designate_warning": "This will also change state of the Order to processing from cancelled. Are you sure you want to designate?"
     "cancel_order_alert": "To cancel the Order, there should be 0 dispatched items."
+    "logistics": {
+      "scheduled": "Scheduled"
+      "type": "Type"
+      "transport_type": "Transport Type"
+      "destination": "Destination"
+      "vehicle_type": "Vehicle Type"
+      "base_estimate": "Base est."
+      "add_note": "Tap to add/edit sticky note"
+      "vehicle": {
+        "self": 'Private vehicle'
+        "van": 'Needs hired vehicle'
+      }
+    }
 
   "order_transports":
     "online_order": "Online Order"

--- a/app/locales/zh-tw/translations.coffee
+++ b/app/locales/zh-tw/translations.coffee
@@ -156,6 +156,19 @@ I18nTranslationsEn =
     "close_order_popup": "此訂單中所有物資已經派送完畢。請確認您要完成訂單。請注意，訂單完成後您將不能再修改訂單内容。"
     "cancel_item_designate_warning":" 請確認繼續指派物資到此訂單。請注意，訂單狀態將會由「已取消」重設為「處理中」。"
     "cancel_order_alert": "如需取消訂單，訂單中只能存有0 件已派送物品。"
+    "logistics": {
+      "scheduled": "Scheduled"
+      "type": "Type"
+      "transport_type": "Transport Type"
+      "destination": "Destination"
+      "vehicle_type": "Vehicle Type"
+      "base_estimate": "Base est."
+      "add_note": "Tap to add/edit sticky note"
+      "vehicle": {
+        "self": 'Private vehicle'
+        "van": 'Needs hired vehicle'
+      }
+    }
 
   "order_transports":
     "online_order": "Online Order"

--- a/app/models/designation.js
+++ b/app/models/designation.js
@@ -43,9 +43,10 @@ export default Model.extend({
   ordersPurposes:     hasMany('ordersPurpose', { async: false }),
   submittedBy:        belongsTo('user', { async: false }),
   bookingType:        belongsTo('booking_type', { async: false }),
-  createdBy:        belongsTo('user', { async: false }),
-  peopleHelped: attr('number'),
-  districtId:       attr('number'),
+  createdBy:          belongsTo('user', { async: false }),
+  peopleHelped:       attr('number'),
+  districtId:         attr('number'),
+  district:           belongsTo('district', { async: false }),
 
   isLocalOrder: Ember.computed('detailType', function(){
     return (this.get('detailType') === 'LocalOrder') || (this.get('detailType') === 'StockitLocalOrder');
@@ -60,6 +61,10 @@ export default Model.extend({
   isOnlineOrder: Ember.computed("bookingType", function () {
     const bookingType = this.get('bookingType');
     return bookingType && bookingType.get('isOnlineOrder');
+  }),
+
+  bookingTypeLabel: Ember.computed('isAppointment', function () {
+    return  this.get('i18n').t(`order_transports.${this.get('isAppointment') ? 'appointment' : 'online_order'}`);
   }),
 
   isDraft: Ember.computed.equal("state", "draft"),

--- a/app/models/gogovan_transport.js
+++ b/app/models/gogovan_transport.js
@@ -1,0 +1,6 @@
+import Model from "ember-data/model";
+import attr from "ember-data/attr";
+
+export default Model.extend({
+  name: attr("string")
+});

--- a/app/models/order_transport.js
+++ b/app/models/order_transport.js
@@ -16,6 +16,7 @@ export default Model.extend({
   needEnglish:          attr("boolean"),
   needCart:             attr("boolean"),
   needCarry:            attr("boolean"),
+  gogovanTransport:     belongsTo('gogovan_transport', { async: false }),
 
   scheduledDate: Ember.computed('scheduledAt', function() {
     return moment(this.get('scheduledAt')).format("D MMMM YYYY");

--- a/app/styles/templates/orders/_detail.scss
+++ b/app/styles/templates/orders/_detail.scss
@@ -68,6 +68,10 @@
       background-color: transparent;
       border: 1px solid white;
     }
+
+    .text-prefix {
+      color: $gainsboro;
+    }
   }
 
   .reschedule-popup .row {

--- a/app/templates/orders/order_types.hbs
+++ b/app/templates/orders/order_types.hbs
@@ -11,15 +11,6 @@
 </section>
 
 <section class="order-booking-tab">
-  {{!-- <div class="row">
-    <div class="columns small-4 text-prefix">
-      {{ t 'order_details.logistics.scheduled' }}
-    </div>
-    <div class="columns small-8 text" {{ action 'openSchedulePopup' }}>
-      <i aria-hidden="true">{{fa-icon 'clock'}}</i>
-      {{ display-datetime model.orderTransport.scheduledAt format="dddd Do MMMM hh:mm a" }}
-    </div>
-  </div> --}}
   {{#each logisticDataRows as |dataRow|}}
     <div class="row">
       <div class="columns small-4 text-prefix">

--- a/app/templates/orders/order_types.hbs
+++ b/app/templates/orders/order_types.hbs
@@ -11,15 +11,26 @@
 </section>
 
 <section class="order-booking-tab">
-  <div class="row">
-    <div class="columns small-8 text">
+  {{!-- <div class="row">
+    <div class="columns small-4 text-prefix">
+      {{ t 'order_details.logistics.scheduled' }}
+    </div>
+    <div class="columns small-8 text" {{ action 'openSchedulePopup' }}>
       <i aria-hidden="true">{{fa-icon 'clock'}}</i>
       {{ display-datetime model.orderTransport.scheduledAt format="dddd Do MMMM hh:mm a" }}
     </div>
-    <div class="columns small-4">
-      <button class="reschedule button light" {{ action 'openSchedulePopup' }}>Reschedule</button>
+  </div> --}}
+  {{#each logisticDataRows as |dataRow|}}
+    <div class="row">
+      <div class="columns small-4 text-prefix">
+        {{ dataRow.label }}
+      </div>
+      <div class="columns small-8 text {{dataRow.name}}" {{ action dataRow.action }}>
+        {{ dataRow.text }}
+        <i aria-hidden="true">{{fa-icon dataRow.icon }}</i>
+      </div>
     </div>
-  </div>
+  {{/each}}
 
   {{#message-box
     btn1Text=(t "save")

--- a/tests/acceptance/order-details-appointment-info-test.js
+++ b/tests/acceptance/order-details-appointment-info-test.js
@@ -1,7 +1,6 @@
 import Ember from "ember";
 import _ from "lodash";
 import { module, test } from "qunit";
-import FactoryGuy from "ember-data-factory-guy";
 import startApp from "../helpers/start-app";
 import "../factories/appointment_slot";
 import "../factories/appointment_slot_preset";
@@ -40,13 +39,17 @@ module("Acceptance: Order details, appointment info", {
 
     const designations = [];
     const orderTransports = [];
+    const ggvTransports = [{ id: 1, name: 'Van' }];
+    const districts = [{ id: 1, name: 'The peak', territory_id: 1}];
 
     const makeDesignation = (bookingType = BOOKING_TYPES.onlineOrder) => {
-      const record = FactoryGuy.make("designation", {
+      const record = {
+        id: _.uniqueId(),
         state: "submitted",
-        detailType: "GoodCity",
-        id: 1103 + designations.length
-      }).toJSON({includeId: true});
+        detail_type: "GoodCity",
+        id: 1103 + designations.length,
+        district_id: 1
+      };
 
       record.booking_type_id = bookingType.id;
 
@@ -54,7 +57,9 @@ module("Acceptance: Order details, appointment info", {
         id: _.uniqueId(),
         designation_id: record.id,
         order_id: record.id,
-        transport_type: 'self'
+        transport_type: 'self',
+        gogovan_transport_id: 1,
+        scheduled_at: "2019-02-14T11:00:00+08:00"
       });
       designations.push(record);
       return record;
@@ -89,7 +94,9 @@ module("Acceptance: Order details, appointment info", {
     mockResource('designation*', {
       designations: designations,
       order_transports: orderTransports,
-      booking_types: _.values(BOOKING_TYPES)
+      booking_types: _.values(BOOKING_TYPES),
+      gogovan_transports: ggvTransports,
+      districts: districts
     });
     mockResource('orders_package*', { orders_packages: [] });
     mockResource('location*', { locations: [] });
@@ -107,27 +114,57 @@ module("Acceptance: Order details, appointment info", {
 
 // ------ Tests
 
-test("Tab's label should be 'Logistics' if the order is a warehouse visit", function(assert) {
-  assert.expect(1);
-
-  visit(`/orders/${designationAppointment.id}/order_types/`);
-
-  andThen(function () {
-    assert.equal($('.tab_row dd.small-3:nth-child(3)').text().trim(), 'Logistics');
-  });
-});
-
-test("Tab's label should be 'Logistics' if the order is an online order", function(assert) {
+test("Should display the vehicle type", function(assert) {
   assert.expect(1);
 
   visit(`/orders/${designationOnlineOrder.id}/order_types/`);
 
   andThen(function () {
-    assert.equal($('.tab_row dd.small-3:nth-child(3)').text().trim(), 'Logistics');
+    assert.equal($('.order-booking-tab .vehicle').text().trim(), 'Van');
   });
 });
 
-test("An order's schedule can be updated", function (assert) {
+test("Should display the district", function(assert) {
+  assert.expect(1);
+
+  visit(`/orders/${designationOnlineOrder.id}/order_types/`);
+
+  andThen(function () {
+    assert.equal($('.order-booking-tab .district').text().trim(), 'The peak');
+  });
+});
+
+test("Should display the schedule", function(assert) {
+  assert.expect(1);
+
+  visit(`/orders/${designationOnlineOrder.id}/order_types/`);
+
+  andThen(function () {
+    assert.equal($('.order-booking-tab .reschedule').text().trim(), 'Thursday 14th February 11:00 am');
+  });
+});
+
+test("Should display the type for an online order", function(assert) {
+  assert.expect(1);
+
+  visit(`/orders/${designationOnlineOrder.id}/order_types/`);
+
+  andThen(function () {
+    assert.equal($('.order-booking-tab .type').text().trim(), 'Online Order');
+  });
+});
+
+test("Should display the type for an appointment", function(assert) {
+  assert.expect(1);
+
+  visit(`/orders/${designationAppointment.id}/order_types/`);
+
+  andThen(function () {
+    assert.equal($('.order-booking-tab .type').text().trim(), 'Appointment');
+  });
+});
+
+test("An order's schedule can be updated by clicking on the schedule line", function (assert) {
   assert.expect(3);
 
   let putRequestSent = false;
@@ -148,7 +185,7 @@ test("An order's schedule can be updated", function (assert) {
   visit(`/orders/${designationAppointment.id}/order_types/`);
 
   andThen(() => {
-    const rescheduleBtn = Ember.$('.order-booking-tab .reschedule.button');
+    const rescheduleBtn = Ember.$('.order-booking-tab .reschedule');
     assert.equal(rescheduleBtn.length, 1);
     click(rescheduleBtn);
   });

--- a/tests/acceptance/order-details-appointment-info-test.js
+++ b/tests/acceptance/order-details-appointment-info-test.js
@@ -44,7 +44,6 @@ module("Acceptance: Order details, appointment info", {
 
     const makeDesignation = (bookingType = BOOKING_TYPES.onlineOrder) => {
       const record = {
-        id: _.uniqueId(),
         state: "submitted",
         detail_type: "GoodCity",
         id: 1103 + designations.length,


### PR DESCRIPTION
Adds extra lines of data to the logistic tabs. Those are not yet editable.

From the design :
<img width="355" alt="screenshot 2019-02-14 at 11 40 42 am" src="https://user-images.githubusercontent.com/1822532/52761189-6795db00-304d-11e9-8cdd-42d568fc4182.png">