### PR TITLE
remove booking_type params from order_transport as we are now saving …

### DIFF
--- a/app/controllers/order/appointment_details.js
+++ b/app/controllers/order/appointment_details.js
@@ -1,64 +1,75 @@
 import Ember from "ember";
-import AjaxPromise from 'stock/utils/ajax-promise';
-import config from '../../config/environment';
+import AjaxPromise from "stock/utils/ajax-promise";
+import config from "../../config/environment";
 const { getOwner } = Ember;
 
 export default Ember.Controller.extend({
   order: Ember.computed.alias("model.orderUserOrganisation.order"),
-  orderTransport: Ember.computed.alias('model.orderTransport'),
+  orderTransport: Ember.computed.alias("model.orderTransport"),
   selectedId: null,
   selectedTimeId: null,
   selectedDate: null,
   timeSlotNotSelected: false,
   isMobileApp: config.cordova.enabled,
 
-  timeSlots: Ember.computed('selectedDate', function(){
-    var selectedDate = this.get('selectedDate');
-    if(selectedDate){
-      var timeSlots = this.get('available_dates').appointment_calendar_dates.filter( date => date.date === moment(selectedDate).format('YYYY-MM-DD'))[0].slots;
+  timeSlots: Ember.computed("selectedDate", function() {
+    var selectedDate = this.get("selectedDate");
+    if (selectedDate) {
+      var timeSlots = this.get(
+        "available_dates"
+      ).appointment_calendar_dates.filter(
+        date => date.date === moment(selectedDate).format("YYYY-MM-DD")
+      )[0].slots;
       return timeSlots;
     }
   }),
 
-  orderTransportParams(){
+  orderTransportParams() {
     var orderTransportProperties = {};
-    orderTransportProperties.scheduled_at = this.get('selectedTimeId');
-    orderTransportProperties.timeslot = this.get('selectedTimeId').substr(11, 5);
+    orderTransportProperties.scheduled_at = this.get("selectedTimeId");
+    orderTransportProperties.timeslot = this.get("selectedTimeId").substr(
+      11,
+      5
+    );
     orderTransportProperties.transport_type = this.get("selectedId");
-    orderTransportProperties.order_id = this.get('order.id');
-    orderTransportProperties.booking_type_id = this.store.peekAll('booking_type').filterBy('nameEn', 'appointment').get('firstObject.id');
+    orderTransportProperties.order_id = this.get("order.id");
     return orderTransportProperties;
   },
 
   actions: {
-    saveTransportDetails(){
-      const isTimeSlotSelected = Ember.$('.time-slots input').toArray().filter(radioButton => radioButton.checked === true).length;
-      if(isTimeSlotSelected) {
+    saveTransportDetails() {
+      const isTimeSlotSelected = Ember.$(".time-slots input")
+        .toArray()
+        .filter(radioButton => radioButton.checked === true).length;
+      if (isTimeSlotSelected) {
         this.set("timeSlotNotSelected", false);
       } else {
         this.set("timeSlotNotSelected", true);
         return false;
       }
-      var orderTransport = this.get('orderTransport');
+      var orderTransport = this.get("orderTransport");
 
       var url, actionType;
 
       if (orderTransport) {
-        url = "/order_transports/" + orderTransport.get('id');
+        url = "/order_transports/" + orderTransport.get("id");
         actionType = "PUT";
       } else {
         url = "/order_transports";
         actionType = "POST";
       }
 
-      this.send('saveOrUpdateOrderTransport', url, actionType);
+      this.send("saveOrUpdateOrderTransport", url, actionType);
     },
 
-    saveOrUpdateOrderTransport(url, actionType){
-      var loadingView = getOwner(this).lookup('component:loading').append();
+    saveOrUpdateOrderTransport(url, actionType) {
+      var loadingView = getOwner(this)
+        .lookup("component:loading")
+        .append();
 
-      new AjaxPromise(url, actionType, this.get('session.authToken'), { order_transport: this.orderTransportParams() })
-      .then(data => {
+      new AjaxPromise(url, actionType, this.get("session.authToken"), {
+        order_transport: this.orderTransportParams()
+      }).then(data => {
         this.get("store").pushPayload(data);
         loadingView.destroy();
         this.transitionToRoute("order.confirm_booking", this.get("order.id"));


### PR DESCRIPTION
Hi Team,

This PR removes the line which was sending booking_type_id param for order_transport which is no longer require as we are saving booking_type_id against order itself.

Main change: https://github.com/crossroads/stock.goodcity/compare/GCW-2362-remove-booking_type_id-from-order-transport#diff-e6c03a28507fa13ad8ba99685887de95L29

Please review.

Thanks.