### PR TITLE
FIX => Wrong redesignate popup on item search page

### DIFF
--- a/app/routes/items/search_order.js
+++ b/app/routes/items/search_order.js
@@ -84,5 +84,12 @@ export default AuthorizeRoute.extend({
     }
     controller.set("searchText", "");
     controller.set("backLinkPath", this.get("itemDesignateBackLinkPath"));
+  },
+
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.set("partial_qty", undefined);
+      controller.set("isSet", undefined);
+    }
   }
 });


### PR DESCRIPTION
Hi Team,
This is fix for wrong popup for designated item on item search page. The issue was due to previous queryparams not getting cleaned up. Issue is fixed.
Please review the PR and let me know if any change is required.
Thanks.