### PR TITLE
Live updates: Support order model (locally named designation)

### DIFF
--- a/app/services/subscription.js
+++ b/app/services/subscription.js
@@ -57,8 +57,7 @@ export default Ember.Service.extend(Ember.Evented, {
     "delivery",
     "gogovan_order",
     "contact",
-    "address",
-    "order"
+    "address"
   ],
   importStrategies: {
     // define how we handle incoming changes
@@ -78,7 +77,8 @@ export default Ember.Service.extend(Ember.Evented, {
   },
   internalTypeMapping: {
     // type renaming
-    package: "item"
+    package: "item",
+    order: "designation"
   },
 
   // -----------


### PR DESCRIPTION
The new push updates changes on api (https://github.com/crossroads/api.goodcity/pull/743) no longer send orders as "designations" (which is a good thing, we want to move away from this terminology).

This PR adds an alias to the subscription service (`order` -> `designation`) in order to support the new updates.