### PR TITLE
Image fixes (back link related) + Default headers for AjaxPromise

### DIFF
--- a/app/controllers/items/new.js
+++ b/app/controllers/items/new.js
@@ -1,10 +1,10 @@
 import Ember from "ember";
-import AjaxPromise from 'stock/utils/ajax-promise';
-import config from '../../config/environment';
+import AjaxPromise from "stock/utils/ajax-promise";
+import config from "../../config/environment";
 const { getOwner } = Ember;
 
 export default Ember.Controller.extend({
-  queryParams: ['codeId', 'locationId', 'scanLocationName', 'caseNumber'],
+  queryParams: ["codeId", "locationId", "scanLocationName", "caseNumber"],
   codeId: "",
   locationId: "",
   inventoryNumber: "",
@@ -12,7 +12,7 @@ export default Ember.Controller.extend({
   displayInventoryOptions: false,
   autoGenerateInventory: true,
   inputInventory: false,
-  locationName: Ember.computed.alias('location.displayName'),
+  locationName: Ember.computed.alias("location.displayName"),
   caseNumber: "",
   isSearchCodePreviousRoute: Ember.computed.localStorage(),
   isSelectLocationPreviousRoute: Ember.computed.localStorage(),
@@ -35,15 +35,17 @@ export default Ember.Controller.extend({
     return +this.get("quantity") === 1;
   }),
 
-  locale: function(str){
+  locale: function(str) {
     return this.get("i18n").t(str);
   },
 
   setLocation: Ember.observer("scanLocationName", function() {
     var scanInput = this.get("scanLocationName");
-    if(scanInput) {
-      var results = this.get("store").peekAll("location").filterBy("displayName", scanInput);
-      if(results.length > 0) {
+    if (scanInput) {
+      var results = this.get("store")
+        .peekAll("location")
+        .filterBy("displayName", scanInput);
+      if (results.length > 0) {
         this.set("invalidScanResult", false);
         this.set("location", results.get("firstObject"));
       } else {
@@ -54,8 +56,8 @@ export default Ember.Controller.extend({
     }
   }),
 
-  validateLocation: Ember.observer('location', function() {
-    if(!this.get("location")) {
+  validateLocation: Ember.observer("location", function() {
+    if (!this.get("location")) {
       this.set("invalidLocation", false);
     }
   }),
@@ -63,7 +65,7 @@ export default Ember.Controller.extend({
   isMobileApp: config.cordova.enabled,
   messageBox: Ember.inject.service(),
 
-  conditions: Ember.computed(function(){
+  conditions: Ember.computed(function() {
     return [
       { name: "New", id: "N" },
       { name: "Mixed", id: "M" },
@@ -72,7 +74,7 @@ export default Ember.Controller.extend({
     ];
   }),
 
-  grades: Ember.computed(function(){
+  grades: Ember.computed(function() {
     return [
       { name: "A", id: "A" },
       { name: "B", id: "B" },
@@ -93,7 +95,7 @@ export default Ember.Controller.extend({
   parentCodeName: Ember.computed("codeId", function() {
     var selected = "";
     var codeId = this.get("codeId");
-    if(codeId.length) {
+    if (codeId.length) {
       selected = this.get("store").peekRecord("code", codeId);
       return selected && selected.get("name");
     }
@@ -103,7 +105,7 @@ export default Ember.Controller.extend({
   code: Ember.computed("codeId", function() {
     var selected = "";
     var codeId = this.get("codeId");
-    if(codeId.length) {
+    if (codeId.length) {
       selected = this.get("store").peekRecord("code", codeId);
       return selected && selected.defaultChildPackagesList()[0];
     }
@@ -115,13 +117,17 @@ export default Ember.Controller.extend({
       var location;
       var locationId = this.get("locationId");
       var codeLocation = this.get("code.location");
-      if(locationId) { this.set("scanLocationName", null); }
-      if(locationId.length) {
+      if (locationId) {
+        this.set("scanLocationName", null);
+      }
+      if (locationId.length) {
         location = this.get("store").peekRecord("location", locationId);
-      } else if(codeLocation) {
+      } else if (codeLocation) {
         location = codeLocation;
       }
-      if(!locationId && location) { this.set("locationId", location.get("id")); }
+      if (!locationId && location) {
+        this.set("locationId", location.get("id"));
+      }
       return location;
     },
     set(key, value) {
@@ -130,36 +136,43 @@ export default Ember.Controller.extend({
   }),
 
   initActionSheet: function(onSuccess) {
-    return window.plugins.actionsheet.show({
-      buttonLabels: [this.locale("edit_images.upload").string, this.locale("edit_images.camera").string, this.locale("edit_images.cancel").string]
-    }, function(buttonIndex) {
-      if (buttonIndex === 1) {
-        navigator.camera.getPicture(onSuccess, null, {
-          quality: 40,
-          destinationType: navigator.camera.DestinationType.DATA_URL,
-          sourceType: navigator.camera.PictureSourceType.PHOTOLIBRARY
-        });
+    return window.plugins.actionsheet.show(
+      {
+        buttonLabels: [
+          this.locale("edit_images.upload").string,
+          this.locale("edit_images.camera").string,
+          this.locale("edit_images.cancel").string
+        ]
+      },
+      function(buttonIndex) {
+        if (buttonIndex === 1) {
+          navigator.camera.getPicture(onSuccess, null, {
+            quality: 40,
+            destinationType: navigator.camera.DestinationType.DATA_URL,
+            sourceType: navigator.camera.PictureSourceType.PHOTOLIBRARY
+          });
+        }
+        if (buttonIndex === 2) {
+          navigator.camera.getPicture(onSuccess, null, {
+            correctOrientation: true,
+            quality: 40,
+            destinationType: navigator.camera.DestinationType.DATA_URL,
+            sourceType: navigator.camera.PictureSourceType.CAMERA
+          });
+        }
+        if (buttonIndex === 3) {
+          window.plugins.actionsheet.hide();
+        }
       }
-      if (buttonIndex === 2) {
-        navigator.camera.getPicture(onSuccess, null, {
-          correctOrientation: true,
-          quality: 40,
-          destinationType: navigator.camera.DestinationType.DATA_URL,
-          sourceType: navigator.camera.PictureSourceType.CAMERA
-        });
-      }
-      if (buttonIndex === 3) {
-        window.plugins.actionsheet.hide();
-      }
-    });
+    );
   },
 
   changeDonorCondition(conditionId) {
     var donorCondition = {
-      "N": 1,
-      "M": 2,
-      "U": 3,
-      "B": 4
+      N: 1,
+      M: 2,
+      U: 3,
+      B: 4
     };
     return donorCondition[conditionId];
   },
@@ -175,15 +188,19 @@ export default Ember.Controller.extend({
       case_number: _this.get("caseNumber"),
       notes: _this.get("description"),
       grade: _this.get("selectedGrade.id"),
-      donor_condition_id: _this.changeDonorCondition(_this.get("selectedCondition.id")),
+      donor_condition_id: _this.changeDonorCondition(
+        _this.get("selectedCondition.id")
+      ),
       location_id: locationId,
       package_type_id: _this.get("code.id"),
-      state_event: 'mark_received',
-      packages_locations_attributes: {0: { location_id: locationId, quantity: quantity }}
+      state_event: "mark_received",
+      packages_locations_attributes: {
+        0: { location_id: locationId, quantity: quantity }
+      }
     };
   },
 
-  updateStoreAndSaveImage(data,loadingView, _this) {
+  updateStoreAndSaveImage(data, loadingView, _this) {
     this.get("store").pushPayload(data);
     var image = this.get("newUploadedImage");
     if (image) {
@@ -196,18 +213,23 @@ export default Ember.Controller.extend({
     this.set("locationId", "");
     this.set("inventoryNumber", "");
     loadingView.destroy();
-    _this.transitionToRoute("items.detail", data.item.id);
+    _this.replaceRoute("items.detail", data.item.id);
   },
 
   getItemConditions(_this) {
-    return (_this.get("quantity").toString().trim().length === 0 ||
-        _this.get("description").trim().length === 0 ||
-        !_this.get("location") ||
-        _this.get("inventoryNumber").trim().length === 0 ||
-        !_this.get('code') ||
-        parseInt(_this.get("length"), 10) === 0 ||
-        parseInt(_this.get("width"), 10) === 0 ||
-        parseInt(_this.get("height"), 10) === 0);
+    return (
+      _this
+        .get("quantity")
+        .toString()
+        .trim().length === 0 ||
+      _this.get("description").trim().length === 0 ||
+      !_this.get("location") ||
+      _this.get("inventoryNumber").trim().length === 0 ||
+      !_this.get("code") ||
+      parseInt(_this.get("length"), 10) === 0 ||
+      parseInt(_this.get("width"), 10) === 0 ||
+      parseInt(_this.get("height"), 10) === 0
+    );
   },
 
   checkPermissionAndScan() {
@@ -217,22 +239,25 @@ export default Ember.Controller.extend({
       let error_message = this.get("i18n").t("camera_scan.permission_error");
       _this.get("messageBox").alert(error_message);
     };
-    let permissionSuccess = (status) => {
+    let permissionSuccess = status => {
       //after requesting check for permission then, permit to scan
-      if( status.hasPermission ) {
+      if (status.hasPermission) {
         _this.scan();
       } else {
         permissionError();
       }
     };
-    permissions.hasPermission(permissions.CAMERA, function( status ){
+    permissions.hasPermission(permissions.CAMERA, function(status) {
       //check permission here
-      if ( status.hasPermission ) {
+      if (status.hasPermission) {
         _this.scan();
-      }
-      else {
+      } else {
         //request permission here
-        permissions.requestPermission(permissions.CAMERA, permissionSuccess, permissionError);
+        permissions.requestPermission(
+          permissions.CAMERA,
+          permissionSuccess,
+          permissionError
+        );
       }
     });
   },
@@ -240,43 +265,46 @@ export default Ember.Controller.extend({
   scan() {
     let onSuccess = res => {
       if (!res.cancelled) {
-        var strippedURL = res.text.substring(res.text.lastIndexOf('=') + 1);
+        var strippedURL = res.text.substring(res.text.lastIndexOf("=") + 1);
         this.set("inventoryNumber", strippedURL);
       }
     };
-    let onError = error => this.get("messageBox").alert("Scanning failed: " + error);
-    let options = {"formats": "QR_CODE, CODE_128", "orientation" : "portrait"};
+    let onError = error =>
+      this.get("messageBox").alert("Scanning failed: " + error);
+    let options = { formats: "QR_CODE, CODE_128", orientation: "portrait" };
     window.cordova.plugins.barcodeScanner.scan(onSuccess, onError, options);
   },
 
   actions: {
-
     //file upload
     triggerUpload() {
-
       // For Cordova application
       if (config.cordova.enabled) {
-        var onSuccess = ((function() {
+        var onSuccess = (function() {
           return function(path) {
             console.log(path);
             var dataURL = "data:image/jpg;base64," + path;
 
-            Ember.$("input[type='file']").fileupload('option', 'formData').file = dataURL;
-            Ember.$("input[type='file']").fileupload('add', { files: [ dataURL ] });
+            Ember.$("input[type='file']").fileupload(
+              "option",
+              "formData"
+            ).file = dataURL;
+            Ember.$("input[type='file']").fileupload("add", {
+              files: [dataURL]
+            });
           };
-        })(this));
+        })(this);
 
         this.initActionSheet(onSuccess);
       } else {
-          // For web application
-        if(navigator.userAgent.match(/iemobile/i))
-        {
+        // For web application
+        if (navigator.userAgent.match(/iemobile/i)) {
           //don't know why but on windows phone need to click twice in quick succession
           //for dialog to appear
-          Ember.$("input[type='file']").click().click();
-        }
-        else
-        {
+          Ember.$("input[type='file']")
+            .click()
+            .click();
+        } else {
           Ember.$("input[type='file']").trigger("click");
         }
       }
@@ -287,19 +315,21 @@ export default Ember.Controller.extend({
     },
 
     uploadStart(e, data) {
-      this.send('deleteUnusedImage');
+      this.send("deleteUnusedImage");
       this.set("uploadedFileDate", data);
       Ember.$(".loading-image-indicator").show();
       this.set("loadingPercentage", "Image Uploading ");
     },
 
     cancelUpload() {
-      if(this.get("uploadedFileDate")){ this.get("uploadedFileDate").abort(); }
+      if (this.get("uploadedFileDate")) {
+        this.get("uploadedFileDate").abort();
+      }
     },
 
     uploadProgress(e, data) {
       e.target.disabled = true; // disable image-selection
-      var progress = parseInt(data.loaded / data.total * 100, 10) || 0;
+      var progress = parseInt((data.loaded / data.total) * 100, 10) || 0;
       this.set("addPhotoLabel", progress + "%");
       this.set("loadingPercentage", "Image Uploading " + progress + "%");
     },
@@ -312,7 +342,12 @@ export default Ember.Controller.extend({
     },
 
     uploadSuccess(e, data) {
-      var identifier = data.result.version + "/" + data.result.public_id + "." + data.result.format;
+      var identifier =
+        data.result.version +
+        "/" +
+        data.result.public_id +
+        "." +
+        data.result.format;
       var newUploadedImage = this.get("store").createRecord("image", {
         cloudinaryId: identifier,
         favourite: true
@@ -326,14 +361,24 @@ export default Ember.Controller.extend({
     },
 
     deleteAutoGeneratedNumber() {
-      new AjaxPromise("/inventory_numbers/remove_number", "PUT", this.get('session.authToken'), { code: this.get('inventoryNumber') });
+      new AjaxPromise(
+        "/inventory_numbers/remove_number",
+        "PUT",
+        this.get("session.authToken"),
+        { code: this.get("inventoryNumber") }
+      );
     },
 
     deleteUnusedImage() {
-      if(this.get('imageKeys.length')) {
-        new AjaxPromise("/images/delete_cloudinary_image", "PUT", this.get('session.authToken'), { cloudinary_id: this.get('imageKeys') });
+      if (this.get("imageKeys.length")) {
+        new AjaxPromise(
+          "/images/delete_cloudinary_image",
+          "PUT",
+          this.get("session.authToken"),
+          { cloudinary_id: this.get("imageKeys") }
+        );
         this.set("imageKeys", "");
-        this.set("newUploadedImage",null);
+        this.set("newUploadedImage", null);
       }
     },
 
@@ -342,7 +387,7 @@ export default Ember.Controller.extend({
         "You will lose all your data. Are you sure you want to cancel this item?",
         "Yes",
         () => {
-          if(this.get("inventoryNumber")) {
+          if (this.get("inventoryNumber")) {
             this.send("deleteAutoGeneratedNumber");
             this.set("inventoryNumber", "");
           }
@@ -350,11 +395,16 @@ export default Ember.Controller.extend({
           this.send("deleteUnusedImage");
           this.set("locationId", "");
           this.set("codeId", "");
-          Ember.run.later(this, function() {
-            this.transitionToRoute("/");
-          },0);
+          Ember.run.later(
+            this,
+            function() {
+              this.replaceRoute("/");
+            },
+            0
+          );
         },
-        "No");
+        "No"
+      );
     },
 
     toggleInventoryOptions() {
@@ -376,8 +426,11 @@ export default Ember.Controller.extend({
       this.set("autoGenerateInventory", true);
       this.set("displayInventoryOptions", false);
 
-      new AjaxPromise("/inventory_numbers", "POST", this.get('session.authToken'))
-      .then(function(data) {
+      new AjaxPromise(
+        "/inventory_numbers",
+        "POST",
+        this.get("session.authToken")
+      ).then(function(data) {
         _this.set("inventoryNumber", data.inventory_number);
       });
     },
@@ -391,27 +444,39 @@ export default Ember.Controller.extend({
     },
 
     saveItem() {
-      if(!window.navigator.onLine){
+      if (!window.navigator.onLine) {
         this.get("messageBox").alert(this.get("i18n").t("offline_error"));
         return false;
       }
       window.localStorage.setItem("isSelectLocationPreviousRoute", false);
       this.set("isSearchCodePreviousRoute", false);
-      var _this = this, loadingView;
+      var _this = this,
+        loadingView;
       var itemConditions = this.getItemConditions(_this);
-      if(itemConditions) {
-        if(!_this.get("location")) { this.set("invalidLocation", true); }
+      if (itemConditions) {
+        if (!_this.get("location")) {
+          this.set("invalidLocation", true);
+        }
         return false;
       } else {
-
-        loadingView = getOwner(this).lookup('component:loading').append();
+        loadingView = getOwner(this)
+          .lookup("component:loading")
+          .append();
         var locationId = this.get("location.id");
         var quantity = this.get("quantity");
-        let isItemAllowedToPublish = Ember.$('#publishItem')[0] && Ember.$('#publishItem')[0].checked;
+        let isItemAllowedToPublish =
+          Ember.$("#publishItem")[0] && Ember.$("#publishItem")[0].checked;
         let publishItem = quantity === 1 ? isItemAllowedToPublish : false;
-        var properties = this.getItemProperties(publishItem, quantity, locationId, _this);
+        var properties = this.getItemProperties(
+          publishItem,
+          quantity,
+          locationId,
+          _this
+        );
 
-        new AjaxPromise("/packages", "POST", this.get('session.authToken'), { package: properties })
+        new AjaxPromise("/packages", "POST", this.get("session.authToken"), {
+          package: properties
+        })
           .then(data => {
             this.updateStoreAndSaveImage(data, loadingView, _this);
           })

--- a/app/controllers/search_code.js
+++ b/app/controllers/search_code.js
@@ -1,82 +1,96 @@
-import Ember from 'ember';
+import Ember from "ember";
 import { translationMacro as t } from "ember-i18n";
-import AjaxPromise from 'stock/utils/ajax-promise';
+import AjaxPromise from "stock/utils/ajax-promise";
 const { getOwner } = Ember;
 
 export default Ember.Controller.extend({
-
   queryParams: ["backToNewItem", "orderId", "changeCode", "reqId"],
   reqId: null,
   backToNewItem: false,
   changeCode: false,
   orderId: null,
-  filter: '',
-  searchText: '',
+  filter: "",
+  searchText: "",
   fetchMoreResult: true,
   searchPlaceholder: t("search.placeholder"),
   i18n: Ember.inject.service(),
   isSearchCodePreviousRoute: Ember.computed.localStorage(),
 
-  allPackageTypes: Ember.computed("fetchMoreResult", function(){
-    return this.store.peekAll('code').filterBy('visibleInSelects', true);
+  allPackageTypes: Ember.computed("fetchMoreResult", function() {
+    return this.store.peekAll("code").filterBy("visibleInSelects", true);
   }),
 
-  hasSearchText: Ember.computed('searchText', function(){
-    return Ember.$.trim(this.get('searchText')).length;
+  hasSearchText: Ember.computed("searchText", function() {
+    return Ember.$.trim(this.get("searchText")).length;
   }),
 
-  hasFilter: Ember.computed('filter', function(){
-    return Ember.$.trim(this.get('filter')).length;
+  hasFilter: Ember.computed("filter", function() {
+    return Ember.$.trim(this.get("filter")).length;
   }),
 
-  onSearchTextChange: Ember.observer('searchText', function () {
+  onSearchTextChange: Ember.observer("searchText", function() {
     // wait before applying the filter
     Ember.run.debounce(this, this.applyFilter, 500);
   }),
 
   applyFilter: function() {
-    this.set('filter', this.get('searchText'));
-    this.set('fetchMoreResult', true);
+    this.set("filter", this.get("searchText"));
+    this.set("fetchMoreResult", true);
   },
 
-  filteredResults: Ember.computed('filter', 'fetchMoreResult', 'allPackageTypes.[]', function(){
-    var filter = Ember.$.trim(this.get('filter').toLowerCase());
-    var types = [];
-    var matchFilter = value => (value || "").toLowerCase().indexOf(filter) !== -1;
+  filteredResults: Ember.computed(
+    "filter",
+    "fetchMoreResult",
+    "allPackageTypes.[]",
+    function() {
+      var filter = Ember.$.trim(this.get("filter").toLowerCase());
+      var types = [];
+      var matchFilter = value =>
+        (value || "").toLowerCase().indexOf(filter) !== -1;
 
-    if (filter.length > 0) {
-      this.get('allPackageTypes').forEach(function(type) {
-        if (matchFilter(type.get('name')) || matchFilter(type.get('otherTerms'))) {
-          types.push(type);
-        }
-      });
-      Ember.run.later(this, this.highlight);
-    } else {
-      types = types.concat(this.get('allPackageTypes').toArray());
-      this.clearHiglight();
+      if (filter.length > 0) {
+        this.get("allPackageTypes").forEach(function(type) {
+          if (
+            matchFilter(type.get("name")) ||
+            matchFilter(type.get("otherTerms"))
+          ) {
+            types.push(type);
+          }
+        });
+        Ember.run.later(this, this.highlight);
+      } else {
+        types = types.concat(this.get("allPackageTypes").toArray());
+        this.clearHiglight();
+      }
+
+      return types.sortBy("name").uniq();
     }
-
-    return types.sortBy("name").uniq();
-  }),
+  ),
 
   highlight() {
-    var string = Ember.$.trim(this.get('filter').toLowerCase());
+    var string = Ember.$.trim(this.get("filter").toLowerCase());
     this.clearHiglight();
-    Ember.$(".codes_results li div").each(function () {
+    Ember.$(".codes_results li div").each(function() {
       var text = Ember.$(this).text();
-      if((text.toLowerCase()).indexOf(string.toLowerCase()) > -1) {
-        var matchStart = text.toLowerCase().indexOf("" + string.toLowerCase() + "");
+      if (text.toLowerCase().indexOf(string.toLowerCase()) > -1) {
+        var matchStart = text
+          .toLowerCase()
+          .indexOf("" + string.toLowerCase() + "");
         var matchEnd = matchStart + string.length - 1;
         var beforeMatch = text.slice(0, matchStart);
         var matchText = text.slice(matchStart, matchEnd + 1);
         var afterMatch = text.slice(matchEnd + 1);
-        Ember.$(this).html(beforeMatch + "<em>" + matchText + "</em>" + afterMatch);
+        Ember.$(this).html(
+          beforeMatch + "<em>" + matchText + "</em>" + afterMatch
+        );
       }
     });
   },
 
   clearHiglight() {
-    Ember.$("em").replaceWith(function() { return this.innerHTML; });
+    Ember.$("em").replaceWith(function() {
+      return this.innerHTML;
+    });
   },
 
   actions: {
@@ -87,38 +101,44 @@ export default Ember.Controller.extend({
       var requestParams = {
         package_type_id: packageType.id
       };
-      var loadingView = getOwner(this).lookup('component:loading').append();
-      new AjaxPromise(url, "PUT", this.get('session.authToken'), { goodcity_request: requestParams })
+      var loadingView = getOwner(this)
+        .lookup("component:loading")
+        .append();
+      new AjaxPromise(url, "PUT", this.get("session.authToken"), {
+        goodcity_request: requestParams
+      })
         .then(data => {
           this.get("store").pushPayload(data);
         })
         .finally(() => {
           loadingView.destroy();
-          this.transitionToRoute("orders.requested_items", designation.id);
+          this.replaceRoute("orders.requested_items", designation.id);
         });
     },
 
     clearSearch(isCancelled) {
-      this.set('filter', '');
-      this.set('searchText', '');
-      this.set('fetchMoreResult', true);
-      if(!isCancelled) { Ember.$("#searchText").focus(); }
+      this.set("filter", "");
+      this.set("searchText", "");
+      this.set("fetchMoreResult", true);
+      if (!isCancelled) {
+        Ember.$("#searchText").focus();
+      }
     },
 
     cancelSearch() {
       Ember.$("#searchText").blur();
       this.send("clearSearch", true);
-      if(this.get("backToNewItem")) {
-        this.transitionToRoute("items.new");
+      if (this.get("backToNewItem")) {
+        this.replaceRoute("items.new");
       } else {
         window.history.back();
       }
     },
 
-    assignItemLabel(type){
+    assignItemLabel(type) {
       this.set("isSearchCodePreviousRoute", true);
-      if(type) {
-        this.transitionToRoute("items.new", { queryParams: { codeId: type.id }});
+      if (type) {
+        this.replaceRoute("items.new", { queryParams: { codeId: type.id } });
       }
     }
   }

--- a/app/controllers/select_location.js
+++ b/app/controllers/select_location.js
@@ -10,8 +10,9 @@ export default searchModule.extend({
   actions: {
     setLocation(location) {
       window.localStorage.setItem("isSelectLocationPreviousRoute", true);
-      this.transitionToRoute("items.new", { queryParams: { locationId: location.get("id") } });
+      this.replaceRoute("items.new", {
+        queryParams: { locationId: location.get("id") }
+      });
     }
   }
-
 });

--- a/app/instance-initializers/ajax.js
+++ b/app/instance-initializers/ajax.js
@@ -1,0 +1,13 @@
+import AjaxPromise from "stock/utils/ajax-promise";
+
+export default {
+  name: "ajax",
+  initialize: function(app) {
+    const { container = app } = app;
+    const adapter = container.lookup("adapter:application");
+
+    AjaxPromise.setDefaultHeaders(() => {
+      return adapter.get("headers");
+    });
+  }
+};

--- a/app/routes/items/new.js
+++ b/app/routes/items/new.js
@@ -90,6 +90,7 @@ export default AuthorizeRoute.extend({
       } else {
         controller.set("newUploadedImage", null);
       }
+      window.localStorage.setItem("isSelectLocationPreviousRoute", false);
     }
   }
 });

--- a/app/routes/items/new.js
+++ b/app/routes/items/new.js
@@ -9,9 +9,15 @@ export default AuthorizeRoute.extend({
   isSelectLocationPreviousRoute: Ember.computed.localStorage(),
 
   queryParams: {
-    codeId: "",
-    locationId: "",
-    scanLocationName: ""
+    codeId: {
+      replace: true
+    },
+    locationId: {
+      replace: true
+    },
+    scanLocationName: {
+      replace: true
+    }
   },
 
   beforeModel() {
@@ -21,7 +27,7 @@ export default AuthorizeRoute.extend({
       var newItemRequest = searchCodePreviousRoute ? true : false;
       this.set("newItemRequest", newItemRequest);
     } else {
-      this.transitionTo("search_code");
+      this.replaceWith("search_code");
     }
   },
 

--- a/app/templates/items/new.hbs
+++ b/app/templates/items/new.hbs
@@ -135,7 +135,7 @@
     </div>
 
     <div class="{{if isMobileApp 'small-7 large-8' 'small-9'}} columns">
-      {{#link-to "select_location"}}
+      {{#link-to "select_location" replace=true}}
         <div class="{{if (is-or invalidLocation invalidScanResult) 'ember-view form__control form__control--error'}}" id="inventory_location">
           <i class="location-icon" aria-hidden="true">{{fa-icon 'map-marker-alt'}}</i>
           {{input value=locationName disabled=true required='true'}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4195,7 +4195,7 @@ cordova-lib@7.1.0:
 
 "cordova-lib@https://github.com/crossroads/goodcity-lib.git#master":
   version "0.0.0"
-  resolved "https://github.com/crossroads/goodcity-lib.git#d67a2d7188b28278b4df3d6369bde289cfe3afce"
+  resolved "https://github.com/crossroads/goodcity-lib.git#f619e0c7ba59b11ebfa3d14356d648591b2982e1"
   dependencies:
     bower "^1.8.8"
     codeclimate-test-reporter "^0.5.0"


### PR DESCRIPTION
# Image fix

The previous issue that was found for images was related to having a bad page state. 
One problem found related to that, is that using the native back button bypasses function calls which are meant to clear/restore state, which leads to even more problems.
Here the solution is to use `replaceWith` instead of `transitionTo`, which solves 2 things: 
- a better user experience since we don't land back into pages which are meant to be "transitional" 
- it prevents from returning to an unknown/incomplete state, which eventually led to images breaking

Generally we want to use `replaceWith` when it comes to search pages (organisations, etc) as they are designed more as popups, so we don't want to keep a history of it.

FYI: If you want to use a replace behaviour with a `link-to` hbs helper, that can be done like this :
`{{#link-to "another_page" replace=true}}`

# Default headers

Previously, when using `AjaxPromise`, it did not properly add the app's headers (notably the device-id header).
We're now setting those headers to be exactly those of the application adapter. So it'll be consistent