### PR TITLE
GCW-2576 update payload according to api

### DIFF
--- a/app/serializers/designation.js
+++ b/app/serializers/designation.js
@@ -1,0 +1,10 @@
+import applicationSerializer from "./application";
+
+export default applicationSerializer.extend({
+  serialize(snapshot, options) {
+    let json = this._super(...arguments);
+    json.stockit_organisation_id = json.organisation_id;
+    json.organisation_id = json.gc_organisation_id;
+    return json;
+  }
+});

--- a/app/serializers/designation.js
+++ b/app/serializers/designation.js
@@ -3,6 +3,7 @@ import applicationSerializer from "./application";
 export default applicationSerializer.extend({
   serialize(snapshot, options) {
     let json = this._super(...arguments);
+    // Dont change the sequence of these two lines below.
     json.stockit_organisation_id = json.organisation_id;
     json.organisation_id = json.gc_organisation_id;
     return json;


### PR DESCRIPTION
Hi Team, this PR includes fixes for organisation missing on few orders. 
The issue which was there was due to the reason of json params we were sending to the API. 

Whenever we update anything in the order from the logistics tab, the updateRecord method was called which caused the use of serializer method. In the params, `organisation_id` was sent null and due to that organisation was removed from the order, and similarly for stockit_organisation, it was updating the GC organisation id in the order. 

I have modified the json just how the api likes it. We'll be sending `stockit_organisation_id` and `organisation_id` param to the API, so that it wont cause the above mentioned issue. 

Please review.
Thanks