### PR TITLE
redirect users to login page instead of showing modal

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -21,7 +21,6 @@ export default {
   ok: "OK",
   done: "Done",
   orders_in_process: "Orders In Process",
-  must_login: "You must login!",
   search_no_results: "Sorry, No results found.",
   version: "Stock v.",
   organisation_title: "Organisation",

--- a/app/locales/zh-tw/translations.js
+++ b/app/locales/zh-tw/translations.js
@@ -19,7 +19,6 @@ export default {
   cancel: "取消",
   ok: "確定",
   done: "Done",
-  must_login: "請登入!",
   search_no_results: "對不起，沒有搜尋結果",
   version: "Stock v.",
   organisation_title: "機構",

--- a/app/routes/authorize.js
+++ b/app/routes/authorize.js
@@ -1,18 +1,14 @@
-import Ember from 'ember';
+import Ember from "ember";
 
 export default Ember.Route.extend({
-  messageBox: Ember.inject.service(),
-  i18n: Ember.inject.service(),
-
   beforeModel(transition) {
-    if (!this.session.get('isLoggedIn')) {
+    if (!this.session.get("isLoggedIn")) {
       transition.abort();
-      this.get('messageBox').alert(this.get("i18n").t('must_login'), () => {
-        var loginController = this.controllerFor('login');
-        loginController.set('attemptedTransition', transition);
-        this.transitionTo('login');
-      });
+      var loginController = this.controllerFor("login");
+      loginController.set("attemptedTransition", transition);
+      this.transitionTo("login");
       return false;
     }
+    return true;
   }
 });


### PR DESCRIPTION
Currrently, if user is logged out and tries to visit any page, we show "You must login!" modal, which looks rude, so this PR removes that modal, and automatically redirects them to the login page.

Keeping in mind which the user was trying to visit, post login user is redirected to that page.