### PR TITLE
GCW-2618 fix missing translations

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -7,6 +7,8 @@ export default {
   "language.zh": "中文",
   switch_language: "Switch language",
   loading: "Loading...",
+  loading_timeout_error: "Loading view timeout reached.",
+  loading_timeout: "This is taking too long! Click okay to reload.",
   back: "Back",
   search: "Search",
   state: "State",

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -726,5 +726,19 @@ export default {
       "Please ensure descriptions and images are high quality before proceeding.",
     unpublish_message:
       "You are about to unpublish this package.Clients will no longer be able to view or request it online."
+  },
+  designate_form: {
+    warning_text:
+      "Increases {{state}} quantity to {{totalQty}} for {{designationCode}}! ({{qty}} previously {{pkgState}} - item {{inventoryNumber}})",
+    warning_text_without_link:
+      "Increases {{state}} quantity to {{totalQty}} for {{orderCode}}! ({{qty}} previously {{designatedState}})",
+    designate_to: "Designate this set of items to {{orderCode}}",
+    designate_entire: "Designates entire quantity.",
+    designate_part: "Designates only part of set."
+  },
+  "dispatch-form": {
+    confirmation: "You must tick the confirmation box to proceed.",
+    dispatch_multipart: "Dispatch multi-part set to {{orderCode}}",
+    dispatch_entire: "Dispatches entire quantity."
   }
 };

--- a/app/locales/zh-tw/translations.js
+++ b/app/locales/zh-tw/translations.js
@@ -717,16 +717,16 @@ export default {
   },
   designate_form: {
     warning_text:
-      "Increases {{state}} quantity to {{totalQty}} for {{designationCode}}! ({{qty}} previously {{pkgState}} - item {{inventoryNumber}})",
+      "增加{{state}}的數量到{{totalQty}} 對於{{designationCode}}! ({{qty}} 原本{{pkgState}}-物件{{inventory number}})",
     warning_text_without_link:
-      "Increases {{state}} quantity to {{totalQty}} for {{orderCode}}! ({{qty}} previously {{designatedState}})",
-    designate_to: "Designate this set of items to {{orderCode}}",
-    designate_entire: "Designates entire quantity.",
-    designate_part: "Designates only part of set."
+      "增加{{state}}的數量到{{totalQty}} 對於{{orderCode}}! ({{qty}} 原本{{designatedState}})",
+    designate_to: "指定這組物件到{{orderCode}}",
+    designate_entire: " 指定全數",
+    designate_part: "指定部份"
   },
   "dispatch-form": {
-    confirmation: "You must tick the confirmation box to proceed.",
-    dispatch_multipart: "Dispatch multi-part set to {{orderCode}}",
-    dispatch_entire: "Dispatches entire quantity."
+    confirmation: " 您必須勾選確認方格才可繼續",
+    dispatch_multipart: " 派送多部份至{{orderCode}}",
+    dispatch_entire: "派送全部數量"
   }
 };

--- a/app/locales/zh-tw/translations.js
+++ b/app/locales/zh-tw/translations.js
@@ -714,5 +714,19 @@ export default {
       "Please ensure descriptions and images are high quality before proceeding.",
     unpublish_message:
       "You are about to unpublish this package.Clients will no longer be able to view or request it online."
+  },
+  designate_form: {
+    warning_text:
+      "Increases {{state}} quantity to {{totalQty}} for {{designationCode}}! ({{qty}} previously {{pkgState}} - item {{inventoryNumber}})",
+    warning_text_without_link:
+      "Increases {{state}} quantity to {{totalQty}} for {{orderCode}}! ({{qty}} previously {{designatedState}})",
+    designate_to: "Designate this set of items to {{orderCode}}",
+    designate_entire: "Designates entire quantity.",
+    designate_part: "Designates only part of set."
+  },
+  "dispatch-form": {
+    confirmation: "You must tick the confirmation box to proceed.",
+    dispatch_multipart: "Dispatch multi-part set to {{orderCode}}",
+    dispatch_entire: "Dispatches entire quantity."
   }
 };

--- a/app/locales/zh-tw/translations.js
+++ b/app/locales/zh-tw/translations.js
@@ -3,6 +3,8 @@ export default {
   unexpected_error: "錯誤",
   okay: "確定",
   loading: "正在加載...",
+  loading_timeout_error: "讀取時限已過",
+  loading_timeout: "需時太久了！點擊重新加載",
   "language.en": "English",
   "language.zh": "中文",
   back: "返回",


### PR DESCRIPTION
Hi team, 
This PR's adds back the tranlations which went missing when we changed the translations file from `.coffee` to `.js`.

Thanks