### PR TITLE
GCW-2780 hide pieces inline edit if allow_pieces is false

### DIFF
--- a/app/controllers/items/detail.js
+++ b/app/controllers/items/detail.js
@@ -42,6 +42,14 @@ export default GoodcityController.extend(singletonItemDispatchToGcOrder, {
     }
   ),
 
+  showPieces: Ember.computed("codeId", function() {
+    let codeId = this.get("codeId");
+    if (codeId) {
+      let selected = this.get("store").peekRecord("code", codeId);
+      return selected && selected.get("allow_pieces");
+    }
+  }),
+
   tabName: Ember.computed("currentRoute", function() {
     return this.get("currentRoute")
       .split(".")

--- a/app/templates/items/detail/tabs/info.hbs
+++ b/app/templates/items/detail/tabs/info.hbs
@@ -105,12 +105,14 @@
             <div class="columns small-3 value weight-field">
               {{numeric-inline-input id=(concat 'wgt' item.id) name="weight" class="numeric-input item-weight small-3" value=item.weight maxlength="10"  item=item}}
             </div>
-            <div class="columns small-3 pieces-field">
-              <span class='input_text'>{{t 'item_details.pieces'}}</span>
-            </div>
-            <div class="columns small-3 value pieces-field">
-              {{numeric-inline-input id=(concat 'pcs' item.id) name="pieces" class="numeric-input item-pieces small-3" value=item.pieces maxlength="10"  item=item}}
-            </div>
+            {{#if showPieces}}
+              <div class="columns small-3 pieces-field">
+                <span class='input_text'>{{t 'item_details.pieces'}}</span>
+              </div>
+              <div class="columns small-3 value pieces-field">
+                {{numeric-inline-input id=(concat 'pcs' item.id) name="pieces" class="numeric-input item-pieces small-3" value=item.pieces maxlength="10"  item=item}}
+              </div>
+            {{/if}}
           </div>
         </div>
       </div>

--- a/app/templates/items/detail/tabs/info.hbs
+++ b/app/templates/items/detail/tabs/info.hbs
@@ -103,14 +103,26 @@
               <span class='input_text'>{{t 'item_details.weight'}}</span>
             </div>
             <div class="columns small-3 value weight-field">
-              {{numeric-inline-input id=(concat 'wgt' item.id) name="weight" class="numeric-input item-weight small-3" value=item.weight maxlength="10"  item=item}}
+              {{numeric-inline-input
+                id=(concat 'wgt' item.id)
+                name="weight"
+                class="numeric-input item-weight small-3"
+                value=item.weight
+                maxlength="10"
+                item=item}}
             </div>
             {{#if showPieces}}
               <div class="columns small-3 pieces-field">
                 <span class='input_text'>{{t 'item_details.pieces'}}</span>
               </div>
               <div class="columns small-3 value pieces-field">
-                {{numeric-inline-input id=(concat 'pcs' item.id) name="pieces" class="numeric-input item-pieces small-3" value=item.pieces maxlength="10"  item=item}}
+                {{numeric-inline-input
+                  id=(concat 'pcs' item.id)
+                  name="pieces"
+                  class="numeric-input item-pieces small-3"
+                  value=item.pieces
+                  maxlength="10"
+                  item=item}}
               </div>
             {{/if}}
           </div>


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2780

### What does this PR do?

- **Missed scenario fixture**: If there is a package_type which has allow_pieces set to false. The pieces in-line edit was available on item details screen. It has now been taken care of.

https://jira.crossroads.org.hk/browse/GCW-2780?focusedCommentId=36166&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-36166

### Impacted Areas
- Item detail page.
