### PR TITLE
Close overlays on navigation

### DIFF
--- a/app/components/goodcity/orders-package-block.js
+++ b/app/components/goodcity/orders-package-block.js
@@ -164,8 +164,7 @@ export default Ember.Component.extend(AsyncMixin, {
         this.get("actionRunner").execAction(ordersPkg, actionName, params)
       );
 
-      // fire & forget
-      this.get("store").findRecord("item", itemId, { reload: true });
+      return this.get("store").findRecord("item", itemId, { reload: true });
     } catch (e) {
       this.onError(e);
     }

--- a/app/initializers/session.js
+++ b/app/initializers/session.js
@@ -1,10 +1,11 @@
 export default {
-  name: 'session',
+  name: "session",
   initialize: function(application) {
-    application.inject('controller', 'session', 'service:session');
-    application.inject('route', 'session', 'service:session');
-    application.inject('component', 'session', 'service:session');
-    application.inject('component', 'router', 'router:main');
-    application.inject('component', 'filterService', 'service:filterService');
+    application.inject("controller", "session", "service:session");
+    application.inject("route", "session", "service:session");
+    application.inject("component", "session", "service:session");
+    application.inject("component", "router", "router:main");
+    application.inject("component", "filterService", "service:filterService");
+    application.inject("service", "router", "router:main");
   }
 };

--- a/app/mixins/navigation_aware.js
+++ b/app/mixins/navigation_aware.js
@@ -1,0 +1,11 @@
+import Ember from "ember";
+import _ from "lodash";
+
+export default Ember.Mixin.create({
+  currentRoute: Ember.computed.alias("router.currentRouteName"),
+
+  routeObserver: Ember.observer("currentRoute", function() {
+    const handler = this.getWithDefault("onNavigation", _.noop);
+    handler.call(this, this.get("currentRoute"));
+  })
+});

--- a/app/mixins/navigation_aware.js
+++ b/app/mixins/navigation_aware.js
@@ -1,6 +1,13 @@
 import Ember from "ember";
 import _ from "lodash";
 
+/**
+ * Adds navigation awareness to component/services
+ *
+ * It provides:
+ *    - A `currentRoute` property
+ *    - Support for an `onNavigation` callback
+ */
 export default Ember.Mixin.create({
   currentRoute: Ember.computed.alias("router.currentRouteName"),
 

--- a/app/services/designation-service.js
+++ b/app/services/designation-service.js
@@ -1,5 +1,6 @@
 import Ember from "ember";
 import ApiBaseService from "./api-base-service";
+import NavigationAwareness from "../mixins/navigation_aware";
 import _ from "lodash";
 
 function ID(modelOrId) {
@@ -21,7 +22,7 @@ function ID(modelOrId) {
  * <br> which mostly involves operations on the orders_package join table
  *
  */
-export default ApiBaseService.extend({
+export default ApiBaseService.extend(NavigationAwareness, {
   store: Ember.inject.service(),
 
   init() {
@@ -121,9 +122,14 @@ export default ApiBaseService.extend({
     this.set("openOrderSearch", true);
     this.set("onOrderSelected", order => {
       this.set("onOrderSelected", _.noop);
+      this.set("openOrderSearch", false);
       deferred.resolve(order || null);
     });
 
     return deferred.promise;
+  },
+
+  onNavigation() {
+    this.getWithDefault("onOrderSelected", _.noop)(null);
   }
 });

--- a/app/services/location-service.js
+++ b/app/services/location-service.js
@@ -1,5 +1,6 @@
 import Ember from "ember";
 import ApiBaseService from "./api-base-service";
+import NavigationAwareness from "../mixins/navigation_aware";
 import _ from "lodash";
 
 /**
@@ -8,12 +9,16 @@ import _ from "lodash";
  * @description Find and pick locations
  *
  */
-export default ApiBaseService.extend({
+export default ApiBaseService.extend(NavigationAwareness, {
   store: Ember.inject.service(),
 
   init() {
     this._super(...arguments);
     this.set("openLocationSearch", false);
+  },
+
+  onNavigation() {
+    this.getWithDefault("onLocationSelected", _.noop)(null);
   },
 
   /**
@@ -31,6 +36,7 @@ export default ApiBaseService.extend({
     this.set("openLocationSearch", true);
     this.set("onLocationSelected", order => {
       this.set("onLocationSelected", _.noop);
+      this.set("openLocationSearch", false);
       deferred.resolve(order || null);
     });
 

--- a/app/services/subscription.js
+++ b/app/services/subscription.js
@@ -12,7 +12,7 @@ const ALL_OPERATIONS = ["create", "update", "delete"];
 
 const UPDATE_STRATEGY = {
   RELOAD: (store, type, record) => {
-    store.findRecord(type, record.id);
+    store.findRecord(type, record.id, { reload: true });
   },
   MERGE: (store, type, record) => {
     store.pushPayload({ [type]: record });

--- a/app/templates/components/goodcity/locations-search-overlay.hbs
+++ b/app/templates/components/goodcity/locations-search-overlay.hbs
@@ -3,7 +3,7 @@
     <div class="main-container">
       <div class="row search-field">
         <div class="icon-holder small-2 columns">
-          <i {{action 'cancel'}} class="back_icon" aria-hidden="true">{{fa-icon 'angle-left' size='lg'}}</i>
+          <i {{action 'cancel'}} class="back_icon" aria-hidden="true">{{fa-icon 'times' size='lg'}}</i>
         </div>
 
         <div class="input-holder small-10 columns">

--- a/app/templates/components/goodcity/orders-search-overlay.hbs
+++ b/app/templates/components/goodcity/orders-search-overlay.hbs
@@ -3,7 +3,7 @@
     <div class="main-container">
       <div class="row search-field">
         <div class="icon-holder small-2 columns">
-          <i {{action 'cancel'}} class="back_icon" aria-hidden="true">{{fa-icon 'angle-left' size='lg'}}</i>
+          <i {{action 'cancel'}} class="back_icon" aria-hidden="true">{{fa-icon 'times' size='lg'}}</i>
         </div>
 
         <div class="input-holder small-10 columns">


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2779

### What does this PR do?

Fixing a couple of issues reported by Tim :

- Due to background reloads, the string "Multiple location" would sometimes appear for a second
- Overlays would not close when navigating away from a page
- Changed the overlay close icons, to differentiate them from "back" navigation actions

### Additions:

Created a `NavigationAwareness` mixin, which can be used to respond to navigation