### PR TITLE
GCW-2854 upgrade android api to 28

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,16 +213,16 @@ jobs:
               echo 'export PATH=$PATH:`yarn bin`' >> $BASH_ENV
               echo 'export PATH=$PATH:$ANDROID_HOME/tools/gradle/bin' >> $BASH_ENV
       - run:
-          name: Install Gradle 3.3
+          name: Install Gradle 4.10.3
           command: |
-            wget -O /tmp/gradle.zip https://downloads.gradle.org/distributions/gradle-3.3-bin.zip
+            wget -O /tmp/gradle.zip  https://services.gradle.org/distributions/gradle-4.10.3-all.zip
             unzip -d $ANDROID_HOME/tools /tmp/gradle.zip
-            mv $ANDROID_HOME/tools/gradle-3.3 $ANDROID_HOME/tools/gradle
+            mv $ANDROID_HOME/tools/gradle-4.10.3 $ANDROID_HOME/tools/gradle
       - run:
           name: Download Google-services file
           command: |
             yarn run azure-filestore download -d stock/$ENVIRONMENT -f google-services.json
-            mv google-services.json ~/code/cordova
+             mv ~/code/google-services.json ~/code/cordova
           working_directory: ~/code
       - run:
           name: Download Keystore File
@@ -230,6 +230,8 @@ jobs:
             yarn run azure-filestore download -f $KEYSTORE
             mv $KEYSTORE ~/code/cordova
           working_directory: ~/code
+      - run: yes | sdkmanager --licenses || exit 0
+      - run: yes | sdkmanager --update || exit 0
       - run:
           name: Download Google Play Store Key file
           command: |
@@ -241,7 +243,7 @@ jobs:
           command: bundle exec rake ${ENVIRONMENT} android app:build
           working_directory: cordova
       - store_artifacts:
-          path: cordova/platforms/android/build/outputs/apk/
+          path: cordova/platforms/android/app/build/outputs/apk/
       - run:
           name: release android build
           command: bundle exec fastlane android ${ENVIRONMENT}

--- a/cordova/config.xml
+++ b/cordova/config.xml
@@ -12,7 +12,7 @@
     <allow-intent href="http://*/*" launch-external="yes" />
     <allow-intent href="https://*/*" launch-external="yes" />
     <platform name="android">
-        <resource-file src="google-services.json" target="google-services.json" />
+        <resource-file src="google-services.json" target="app/google-services.json" />
         <preference name="AndroidLaunchMode" value="singleInstance" />
         <preference name="LoadUrlTimeoutValue" value="120000" />
         <preference name="SplashScreen" value="screen" />
@@ -88,7 +88,7 @@
         <host event="redirectToItem" name="stock.goodcity.hk" scheme="https" />
     </universal-links>
     <engine name="windows" spec="~4.3.1" />
-    <engine name="android" spec="^6.3.0" />
+    <engine name="android" spec="8.0.0" />
     <engine name="ios" spec="~4.5.5" />
     <plugin name="cordova-plugin-android-permissions" spec="https://github.com/NeoLSN/cordova-plugin-android-permissions" />
     <plugin name="cordova-plugin-statusbar" spec="~2.1.1" />

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -62,8 +62,7 @@ end
 platform :android do
 
   before_all do
-    apk_file_path = Dir["#{ENV["CIRCLE_ARTIFACTS"]}/**/*.apk"].first
-    ENV["SUPPLY_APK"] = ENV["TESTFAIRY_IPA_PATH"] = apk_file_path
+    ENV["SUPPLY_APK"] = ENV["TESTFAIRY_IPA_PATH"] = Dir["#{ENV["APK_FILE_PATH"]}"].first
     raise_if_no_env_var("GOOGLE_PLAY_KEY_FILE")
     ENV["SUPPLY_JSON_KEY"] = File.join(Dir.pwd, ENV["GOOGLE_PLAY_KEY_FILE"])
     raise "Google Play private key file not found! (#{ENV["SUPPLY_JSON_KEY"]})" unless File.exist?(ENV["SUPPLY_JSON_KEY"])


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2854

### What does this PR do?

It upgrades the android version to point API level 28. 

### Why ? 
Starting November 1, 2019, updates to apps and games on Google Play will be required to target Android 9 (API level 28) or higher. After this date, the Play Console will prevent you from submitting new APKs with a targetSdkVersion less than 28.

NOTE:  Circle ci 2 provides environment variable `CIRCLE_ARTIFACT` which we used previously and it used to point to the path where apk used to save on CI. 

`CIRCLE_ARTIFACT` path = /home/circleci/code/cordova/platforms/android/build/outputs/apk/*.apk

Path where APK gets created after android 7 = /home/circleci/code/cordova/platforms/android/app/build/outputs/apk/debug/*.apk

Thus I have replaced `CIRCLE_ARTIFACT` with new required path.

https://forum.ionicframework.com/t/build-apk-successful-but-no-apk-found-and-build-directory-did-not-found-too/126921

### How I verified android api version is upgraded?

I have used apk analyzer inside an android studio.
![Screen Shot 2019-11-12 at 8 22 53 PM](https://user-images.githubusercontent.com/8424592/68681909-446f6c00-058a-11ea-8244-a2b31dc3bd6d.png)


android:targetSdkVersion: An integer designating the API Level that the application targets.

https://developer.android.com/guide/topics/manifest/uses-sdk-element

Please review.

Thanks.