### PR TITLE
Clicking on an orders_packages navigates to order detail

### DIFF
--- a/app/components/goodcity/orders-package-block.js
+++ b/app/components/goodcity/orders-package-block.js
@@ -198,5 +198,11 @@ export default Ember.Component.extend(AsyncMixin, {
         })
       );
     }
-  )
+  ),
+
+  actions: {
+    redirectToOrderDetail: function(orderId) {
+      this.router.transitionTo("orders.detail", orderId);
+    }
+  }
 });

--- a/app/helpers/back-action.js
+++ b/app/helpers/back-action.js
@@ -1,0 +1,18 @@
+import Ember from "ember";
+
+/**
+ * Creates an action which backs to the previous page
+ *
+ * Example:
+ *
+ * <button {{action (back-action)}}>
+ *  Go Back
+ * </button>
+ *
+ * @returns {Function} the back action
+ */
+export default Ember.Helper.helper(function([self, propName]) {
+  return function() {
+    window.history.back();
+  };
+});

--- a/app/styles/templates/components/_side_drawer.scss
+++ b/app/styles/templates/components/_side_drawer.scss
@@ -24,6 +24,7 @@
     right: 2em;
     top: 0;
     overflow: hidden;
+    pointer-events: none;
 
     .content {
       transition: transform 0.1s ease-in;
@@ -34,6 +35,7 @@
 
       &.open {
         transform: translateX(0%);
+        pointer-events: all;
       }
     }
   }

--- a/app/templates/components/back-link.hbs
+++ b/app/templates/components/back-link.hbs
@@ -1,0 +1,3 @@
+<a class="back" {{action (back-action)}}>
+  {{yield}}
+</a>

--- a/app/templates/components/goodcity/orders-package-block.hbs
+++ b/app/templates/components/goodcity/orders-package-block.hbs
@@ -3,7 +3,7 @@
     <div>{{fa-icon (orders-package-icon orderPkg.state) size='lg'}}</div>
     <div>{{orderPkg.quantity}}</div>
   </div>
-  <div class="columns small-9 sub-block main {{ orderPkg.designation.state }}">
+  <div class="columns small-9 sub-block main {{ orderPkg.designation.state }}" {{action 'redirectToOrderDetail' orderPkg.designation.id}}>
     <div class="row">
       <div class="columns small-11 text-align-left">
         {{fa-icon orderPkg.designation.transportIcon size='lg'}}

--- a/app/templates/orders/_orders_back_link_path.hbs
+++ b/app/templates/orders/_orders_back_link_path.hbs
@@ -19,16 +19,11 @@
       <i class="back_icon" aria-hidden="true">{{fa-icon 'angle-left'}}</i>
       <div>{{t "back"}}</div>
     {{/link-to}}
-  {{else if (is-or filterService.getOrderStateFilters.length filterService.getOrderTypeFilters.length)}}
-      {{#link-to "orders.index" (query-params isFiltered=true) classNames="back" }}
-        <i class="back_icon" aria-hidden="true">{{fa-icon 'angle-left'}}</i>
-        <div>{{t "back"}}</div>
-      {{/link-to}}
   {{else}}
-    {{#link-to "orders.index" classNames="back" }}
+    {{#back-link}}
       <i class="back_icon" aria-hidden="true">{{fa-icon 'angle-left'}}</i>
       <div>{{t "back"}}</div>
-    {{/link-to}}
+    {{/back-link}}
   {{/if}}
 </section>
 


### PR DESCRIPTION
### Ticket Link: 

Quick addition to https://jira.crossroads.org.hk/browse/GCW-2779

### What does this PR do?

When clicking on an orders_package block on the Item details page, it redirects to the order details

### Impacted Areas

Item details > publishing tab > orders_package block

### Additions

Created a `back-link` component which uses the default browser back navigation. We've long known that hardcoding the back links it not acceptable, so hopefully this is a stepping stone

```
{{#back-link}}
   <div> Click me to go back ! </div>
{{/back-link}}
```
