### PR TITLE
Use new orders_package component on the orders details page

### DIFF
--- a/app/components/goodcity/orders-package-block.js
+++ b/app/components/goodcity/orders-package-block.js
@@ -201,8 +201,20 @@ export default Ember.Component.extend(AsyncMixin, {
   ),
 
   actions: {
-    redirectToOrderDetail: function(orderId) {
+    redirectToOrderDetail(orderId) {
       this.router.transitionTo("orders.detail", orderId);
+    },
+
+    redirectToItemDetails(itemId) {
+      this.router.transitionTo("items.detail", itemId);
+    },
+
+    redirectToDetails() {
+      if (this.get("packageView")) {
+        this.send("redirectToItemDetails", this.get("orderPkg.item.id"));
+      } else {
+        this.send("redirectToOrderDetail", this.get("orderPkg.designation.id"));
+      }
     }
   }
 });

--- a/app/styles/_colors.scss
+++ b/app/styles/_colors.scss
@@ -10,12 +10,12 @@ $cancelled-state-color: #000000;
 $closed-state-color: #000000;
 
 $colors-by-state: (
-  "submitted": $submitted-state-color,
-  "processing": $processing-state-color,
-  "scheduled": $scheduled-state-color,
-  "dispatching": $dispatching-state-color,
-  "cancelled": $cancelled-state-color,
-  "closed": $closed-state-color
+  "state-submitted": $submitted-state-color,
+  "state-processing": $processing-state-color,
+  "state-awaiting_dispatch": $scheduled-state-color,
+  "state-dispatching": $dispatching-state-color,
+  "state-cancelled": $cancelled-state-color,
+  "state-closed": $closed-state-color
 );
 
 @mixin auto-order-state-color($prop : 'background-color') {

--- a/app/styles/templates/components/goodcity/_orders_package_block.scss
+++ b/app/styles/templates/components/goodcity/_orders_package_block.scss
@@ -11,6 +11,12 @@
     font-size: 0.8rem;
   }
 
+  &.state-cancelled {
+    .sub-block.left {
+      background-color: black;
+    }
+  }
+
   .sub-block {
     height: 6em;
     color: white;
@@ -19,24 +25,32 @@
       margin-bottom: 1em;
     }
 
-    .side-drawer {
-      // padding: 1em;
-    }
-
-    &:first-child {
-      border-right: 0.2em solid #002352;
-    }
-
-    &.left {
+    &.left{
       padding: 1em;
       background-color: #27436C;
       text-align: center;
+      border-right: 0.2em solid #002352;
     }
 
     &.main {
-      @include auto-order-state-color('background-color');
-      padding: 1em;
-      padding-left: 1.5em;
+      background-color: #051D3F;
+      &.state-color {
+        @include auto-order-state-color('background-color');
+      }
+      .row, .columns {
+        height: 100%;
+        &.no-padding {
+          padding: 0;
+        }
+      }
+      .text-block {
+        padding: 1em;
+        padding-left: 1.5em;
+
+        .line {
+          margin-bottom: 0.5rem;
+        }
+      }
       svg {
         margin-right: 0.4em;
       }
@@ -46,6 +60,15 @@
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
+      }
+
+      .thumbnail {
+        width: 100%;
+        height: 100%;
+        background-color: #27436C;
+        background-size: cover;
+        background-position: center;
+        background-repeat: no-repeat;
       }
     }
   }

--- a/app/templates/components/goodcity/orders-package-block.hbs
+++ b/app/templates/components/goodcity/orders-package-block.hbs
@@ -1,27 +1,43 @@
-<div class="row gc-orders-package-block">
+<div class="row gc-orders-package-block state-{{orderPkg.state}}">
   <div class="columns small-2 sub-block left">
     <div>{{fa-icon (orders-package-icon orderPkg.state) size='lg'}}</div>
     <div>{{orderPkg.quantity}}</div>
   </div>
-  <div class="columns small-9 sub-block main {{ orderPkg.designation.state }}" {{action 'redirectToOrderDetail' orderPkg.designation.id}}>
-    <div class="row">
-      <div class="columns small-11 text-align-left">
-        {{fa-icon orderPkg.designation.transportIcon size='lg'}}
-        {{ orderPkg.designation.code }}
+  <div class="columns small-9 sub-block main state-{{ orderPkg.designation.state }} {{unless packageView 'state-color'}}" {{action 'redirectToDetails'}}>
+    {{#if packageView}}
+      <div class="row">
+        <div class="columns small-10">
+          <div class="text-block">
+            <div class="line">{{fa-icon 'tag' size='lg'}} {{ orderPkg.item.inventoryNumber }}</div>
+            <div class="line">{{ orderPkg.item.notes }}</div>
+          </div>
+        </div>
+        <div class="columns small-2 no-padding">
+          <div class="thumbnail" style="background-image: url({{orderPkg.item.thumbImageUrl}})"></div>
+        </div>
       </div>
-      <div class="columns small-1 text-align-left">
-        {{fa-icon orderPkg.designation.stateIcon size='lg'}}
+    {{else}}
+      <div class="text-block">
+        <div class="row">
+          <div class="columns small-11 text-align-left">
+            {{fa-icon orderPkg.designation.transportIcon size='lg'}}
+            {{ orderPkg.designation.code }}
+          </div>
+          <div class="columns small-1 text-align-left">
+            {{fa-icon orderPkg.designation.stateIcon size='lg'}}
+          </div>
+        </div>
+        <div class="row">
+          <div class="org-name">
+            {{#if orderPkg.designation.isGoodCityOrder}}
+              {{ orderPkg.designation.gcOrganisation.nameEn }}
+            {{else}}
+              {{ orderPkg.designation.organisation.name }}
+            {{/if}}
+          </div>
+        </div>
       </div>
-    </div>
-    <div class="row">
-      <div class="org-name">
-        {{#if orderPkg.designation.isGoodCityOrder}}
-          {{ orderPkg.designation.gcOrganisation.nameEn }}
-        {{else}}
-          {{ orderPkg.designation.organisation.name }}
-        {{/if}}
-      </div>
-    </div>
+    {{/if}}
   </div>
   <div class="columns small-1 sub-block">
     {{action-drawer actionList=actionList}}

--- a/app/templates/orders/active_items.hbs
+++ b/app/templates/orders/active_items.hbs
@@ -24,11 +24,11 @@
   {{/unless}}
 
   {{#each canceledItemsList as |ordersPackage|}}
-    {{partial "orders/cancelled_orders_packages"}}
+    {{goodcity/orders-package-block orderPkg=ordersPackage packageView=true}}
   {{/each}}
 
   {{#each itemsList as |ordersPackage|}}
-    {{partial "orders/orders_packages"}}
+    {{goodcity/orders-package-block orderPkg=ordersPackage packageView=true}}
   {{/each}}
 
   <div class="row show_more" >


### PR DESCRIPTION
### Ticket Link: 

GCW-2779

### What does this PR do?

Use the `orders_package` blocks that got created for GCW-2779 on Order > Goods tab.

Given that they are the exact same thing but look slightly different I added a `packageView=true` flag which allows to toggle between the 2 display modes.

No differences apart from that.

### Impacted Areas

Orders > Goods tab
