### PR TITLE
String sanitization prevents chinese characters in the organisation search

### DIFF
--- a/app/controllers/search_organisation.js
+++ b/app/controllers/search_organisation.js
@@ -1,7 +1,6 @@
 import Ember from "ember";
-import searchModule from "./search_module";
 
-export default searchModule.extend({
+export default Ember.Controller.extend({
   minSearchTextLength: 3,
   displayResults: false,
 
@@ -23,7 +22,7 @@ export default searchModule.extend({
   actions: {
     cancelSearch() {
       Ember.$("#searchText").blur();
-      this.send("clearSearch", true);
+      this.set("searchText", "");
       this.transitionToRoute("app_menu_list");
     },
 


### PR DESCRIPTION
Remove reference to old (and soon to disappear) `search_module`

This search had been refactored with the new infinite list, but the reference to the old search_module was still there. And it was trimming the chinese characters out of the search text.

I simply removed that reference which is not needed.