### PR TITLE
GCW-2928-edit subform

### DIFF
--- a/app/controllers/items/detail.js
+++ b/app/controllers/items/detail.js
@@ -71,7 +71,7 @@ export default GoodcityController.extend(
           nameEn: country.get("nameEn")
         };
       }
-    }),
+    }).volatile(),
 
     returnSelectedValues(selectedValues) {
       let dataObj = {

--- a/app/controllers/items/select_code.js
+++ b/app/controllers/items/select_code.js
@@ -72,7 +72,10 @@ export default SearchCode.extend({
     const packageParams = {
       package_type_id: type.get("id")
     };
-    if (!this.isSamePackage(type)) {
+    if (
+      !this.isSamePackage(type) ||
+      (!item.get("detailId") && this.isSubformPackage(type))
+    ) {
       packageParams.detail_type = capitalize(type.get("subform"));
     }
     if (deleteDetailId) {

--- a/app/controllers/items/select_code.js
+++ b/app/controllers/items/select_code.js
@@ -23,9 +23,11 @@ export default SearchCode.extend({
     const item = this.get("item");
     const type = item.get("detailType");
     const detailId = item.get("detailId");
-    await this.runTask(
-      this.get("subformDetailService").deleteDetailType(type, detailId)
-    );
+    if (type) {
+      await this.runTask(
+        this.get("subformDetailService").deleteDetailType(type, detailId)
+      );
+    }
     return this.assignNew(packageType, {
       deleteDetailId: !this.isSubformPackage(packageType)
     });


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2928

### What does this PR do?

BUG:  
1) when changing the package type from one with extra fields that have content in them to the same package type (or a different one with the same extra fields), the contents in the 'Country of Origin' dropdown field is deleted.
2) older items with a package type that should have the extra fields (but don't) can have their package type changed to a different package type and back again to have the extra fields, but a different package type must be first selected. If the the same package type is first chosen and then a different package type, the confirmation pop-up appears but doesn't continue past the package type selection page.

### Impacted Areas

Item detail screen.