### PR TITLE
Old rollbar client needs to be disabled on dev envs.

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -10,6 +10,7 @@ module.exports = function(environment) {
     defaultLocationType: "auto",
 
     emberRollbarClient: {
+      enabled: environment !== "test" && environment !== "development",
       accessToken: "cc46e2e6402f4106a8ba71fe9752d69a",
       verbose: true,
       ignoredMessages: ["TransitionAborted"],


### PR DESCRIPTION
### Ticket Link: 

Turns off Rollbar for development environment

### What does this PR do?

BUG: When reporting rollbar errors, we're not interested in development environment ones.

The docs for ember-rollbar-client (v0.9) indicate that development environment is ignore, however, we are currently using v0.2.2 which only ignores testing. We need to add this clause back in.