### PR TITLE
Edge compatibility fix

### DIFF
--- a/app/initializers/browser_compatibility.js
+++ b/app/initializers/browser_compatibility.js
@@ -1,0 +1,12 @@
+export default {
+  name: "browser_compatibility",
+  initialize: function() {
+    if (!Promise.prototype.finally) {
+      // Edge does not support promise.finally, which is used within many ember components
+      // We add it when missing
+      Promise.prototype.finally = function(fn) {
+        this.then(fn);
+      };
+    }
+  }
+};


### PR DESCRIPTION
`Promise.finally` does not exist on Edge, causing a lot of issues which are often reported by Tim(s)

This little fix simply adds the `finally` method when not available