### PR TITLE
GCW-3007 create computed property for highlighting

### DIFF
--- a/app/controllers/orders/detail.js
+++ b/app/controllers/orders/detail.js
@@ -37,10 +37,21 @@ export default GoodcityController.extend(SearchMixin, {
       .get("lastObject");
   }),
 
+  highlightSelectedTabs: Ember.computed("tabName", function() {
+    return (
+      ["client_summary", "contact_summary"].indexOf(this.get("tabName")) >= 0
+    );
+  }),
+
   scheduleTimeSlots: Ember.computed(function() {
     let buildSlot = (hours, minutes) => {
       const key = this.formatTimeSlot(hours, minutes);
-      return { name: key, id: key, hours, minutes };
+      return {
+        name: key,
+        id: key,
+        hours,
+        minutes
+      };
     };
     let slots = _.range(0, 23).map(h => [0, 30].map(m => buildSlot(h, m)));
     return _.flatten(slots);

--- a/app/controllers/orders/detail.js
+++ b/app/controllers/orders/detail.js
@@ -37,7 +37,7 @@ export default GoodcityController.extend(SearchMixin, {
       .get("lastObject");
   }),
 
-  highlightSelectedTabs: Ember.computed("tabName", function() {
+  highlightSelectedTab: Ember.computed("tabName", function() {
     return (
       ["client_summary", "contact_summary"].indexOf(this.get("tabName")) >= 0
     );

--- a/app/templates/orders/_order_tabs.hbs
+++ b/app/templates/orders/_order_tabs.hbs
@@ -3,7 +3,7 @@
     <div class="small-12 columns tab_row">
       <dl class="tabs" data-tab>
         <dd class="small-3 medium-3 columns text-center
-          {{if highlightSelectedTabs 'active'}}">
+          {{if highlightSelectedTab 'active'}}">
           {{#link-to 'orders.contact_summary' model.id replace=true}}
           <i>{{fa-icon 'id-card'}}</i>
           <div>{{t "order_tabs.summary"}}</div>

--- a/app/templates/orders/_order_tabs.hbs
+++ b/app/templates/orders/_order_tabs.hbs
@@ -2,32 +2,33 @@
   <div class="row">
     <div class="small-12 columns tab_row">
       <dl class="tabs" data-tab>
-        <dd class="small-3 medium-3 columns text-center {{if (is-equal tabName 'contact_summary') 'active'}}">
+        <dd class="small-3 medium-3 columns text-center
+          {{if highlightSelectedTabs 'active'}}">
           {{#link-to 'orders.contact_summary' model.id replace=true}}
-            <i>{{fa-icon 'id-card'}}</i>
-            <div>{{t "order_tabs.summary"}}</div>
+          <i>{{fa-icon 'id-card'}}</i>
+          <div>{{t "order_tabs.summary"}}</div>
           {{/link-to}}
         </dd>
 
         <dd class="small-3 medium-3 columns text-center {{if (is-equal tabName 'active_items') 'active'}}">
           {{#link-to 'orders.active_items' model.id replace=true}}
-            <i class="item-menu">{{fa-icon 'shopping-basket'}}</i>
-            <div>{{t "order_tabs.goods"}}</div>
+          <i class="item-menu">{{fa-icon 'shopping-basket'}}</i>
+          <div>{{t "order_tabs.goods"}}</div>
           {{/link-to}}
         </dd>
 
         <dd class="small-3 medium-3 columns text-center {{if (is-equal tabName 'order_types') 'active'}}">
           {{#link-to 'orders.order_types' model.id replace=true}}
-            <i>{{fa-icon 'truck'}}</i>
-            <div>{{t "order_tabs.logistics"}}</div>
+          <i>{{fa-icon 'truck'}}</i>
+          <div>{{t "order_tabs.logistics"}}</div>
           {{/link-to}}
         </dd>
 
         <dd class="small-3 medium-3 columns text-center {{if (is-equal tabName 'conversation') 'active'}}">
           {{#link-to 'orders.conversation' model.id replace=true}}
-            {{partial 'orders/unread_message_bubble'}}
-            <i>{{fa-icon 'comments'}}</i>
-            <div>{{t "order_tabs.chat"}}</div>
+          {{partial 'orders/unread_message_bubble'}}
+          <i>{{fa-icon 'comments'}}</i>
+          <div>{{t "order_tabs.chat"}}</div>
           {{/link-to}}
         </dd>
       </dl>

--- a/app/templates/orders/_summary_tabs.hbs
+++ b/app/templates/orders/_summary_tabs.hbs
@@ -2,13 +2,13 @@
   <div class="row">
     <div class="small-12 columns tab_row">
       <dl class="tabs" data-tab>
-        <dd class="small-6 medium-6 columns text-center">
+        <dd class="small-6 medium-6 columns text-center {{if (is-equal tabName 'contact_summary') 'active'}}">
           {{#link-to 'orders.contact_summary' model.id replace=true}}
             <div>{{t 'order_summary_tabs.contact'}}</div>
           {{/link-to}}
         </dd>
 
-        <dd class="small-6 medium-6 columns text-center">
+        <dd class="small-6 medium-6 columns text-center {{if (is-equal tabName 'client_summary') 'active'}}">
           {{#link-to 'orders.client_summary' model.id replace=true}}
             <div>{{t "order_summary_tabs.client"}}</div>
           {{/link-to}}


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3007

### What does this PR do?

BUG: Sub-tabs(Contact and Purpose/client) under order summary  were not getting highlighted.

Fix: Added is-equal helper in template of orders.summary_tabs and also defined a computed property highlightSelectedTab in controller of orders/detail.js and used it in template of orders_tabs

### Impacted Areas

Home>Recent Order> Select Any order>Summary


## Main changes:
highlightSelectedTab