### PR TITLE
GCW-2101 Scanner gets the item's number on search tab if scanned more than one…

### DIFF
--- a/app/controllers/items/index.js
+++ b/app/controllers/items/index.js
@@ -33,6 +33,15 @@ export default Ember.Controller.extend(SearchMixin, {
     }
   }),
 
+  scannedText: Ember.observer("searchText", function() {
+    const searchInput = this.get("searchText") || "";
+    this.set("searchInput", this.sanitizeString(searchInput));
+  }),
+
+  hasSearchText: Ember.computed("searchText", function() {
+    return Ember.$.trim(this.get("searchText")).length;
+  }),
+
   getFilterQuery() {
     let filterService = this.get("filterService");
     let utilities = this.get("utilityMethods");
@@ -74,6 +83,10 @@ export default Ember.Controller.extend(SearchMixin, {
         .then(results => {
           return results;
         });
+    },
+
+    clearSearch() {
+      this.set("searchText", "");
     }
   }
 });

--- a/app/controllers/orders/index.js
+++ b/app/controllers/orders/index.js
@@ -25,6 +25,10 @@ export default Ember.Controller.extend(SearchMixin, {
     }
   },
 
+  hasSearchText: Ember.computed("searchText", function() {
+    return Ember.$.trim(this.get("searchText")).length;
+  }),
+
   getFilterQuery() {
     const filterService = this.get("filterService");
     const utils = this.get("utilityMethods");
@@ -70,6 +74,10 @@ export default Ember.Controller.extend(SearchMixin, {
           this.afterSearch(results);
           return results;
         });
+    },
+
+    clearSearch() {
+      this.set("searchText", "");
     }
   }
 });


### PR DESCRIPTION
### Ticket Link: 
https://jira.crossroads.org.hk/browse/GCW-2101

### What does this PR do?

Scanning the same barcode twice or more makes it viewable

BUG: Scanning the same barcode twice makes inventory no. unviewable

NOTE: The observer present was triggering only once based based on query params for which another observer was added to have a check on search Text which resolved the issue.

###main change :
 scannedText
