### PR TITLE
GCW-2893-Offer package link UI fixes

### DIFF
--- a/app/components/goodcity/offers-search-overlay.js
+++ b/app/components/goodcity/offers-search-overlay.js
@@ -16,6 +16,8 @@ export default Ember.Component.extend(SearchMixin, {
   autoLoad: true,
   store: Ember.inject.service(),
   offerService: Ember.inject.service(),
+  messageBox: Ember.inject.service(),
+  i18n: Ember.inject.service(),
   perPage: 25,
   isMobileApp: config.cordova.enabled,
   offer_state: {
@@ -24,6 +26,9 @@ export default Ember.Component.extend(SearchMixin, {
 
   actions: {
     loadMoreOffers(pageNo) {
+      const singleOfferWarning = this.get("i18n").t(
+        "search_offer.offer_select_warning"
+      );
       const params = this.trimQuery(
         _.merge(
           {
@@ -40,7 +45,14 @@ export default Ember.Component.extend(SearchMixin, {
         .query("offer", params)
         .then(offers => {
           if (this.get("isMobileApp") && offers.get("length") == 1) {
-            this.send("selectOffer", offers.get("firstObject"));
+            this.get("messageBox").custom(
+              singleOfferWarning,
+              "Yes",
+              () => {
+                this.send("selectOffer", offers.get("firstObject"));
+              },
+              "No"
+            );
           }
           return offers;
         });

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -600,6 +600,9 @@ export default {
       no_bookings_allowed: "No bookings will be allowed for this date"
     }
   },
+  search_offer: {
+    offer_select_warning: "Do you want to assign this offer?"
+  },
   search_order: {
     recent: "Recently used designations"
   },

--- a/app/locales/zh-tw/translations.js
+++ b/app/locales/zh-tw/translations.js
@@ -585,6 +585,9 @@ export default {
       no_bookings_allowed: "此日期不允許預約"
     }
   },
+  search_offer: {
+    offer_select_warning: "Do you want to assign this offer?"
+  },
   search_order: {
     recent: "Recently used designations"
   },

--- a/app/routes/items/new.js
+++ b/app/routes/items/new.js
@@ -93,6 +93,7 @@ export default AuthorizeRoute.extend({
     controller.set("invalidLocation", false);
     controller.set("invalidScanResult", false);
     controller.set("labels", 1);
+    controller.set("offersLists", []);
   },
 
   async manageSubformDetails() {

--- a/app/styles/templates/components/_offer_tags.scss
+++ b/app/styles/templates/components/_offer_tags.scss
@@ -7,9 +7,15 @@
 
   @media #{$small-only} {
     padding: 2%;
+    font-size: 80%;
   }
 
-  svg { font-size: 120%; }
+  svg {
+    font-size: 120%;
+    @media #{$large-only} {
+      font-size: 100%;
+    }
+  }
   .offer-icon { margin-right: 5px; }
   .delete-offer { margin-left: 5px; }
 }

--- a/app/styles/templates/components/_offer_tags.scss
+++ b/app/styles/templates/components/_offer_tags.scss
@@ -2,12 +2,11 @@
   display: inline-block;
   padding:1%;
   margin:3px;
-  border-radius: 5%;
+  border-radius: 10px;
   border: 1px solid #466082;
 
   @media #{$small-only} {
     padding: 2%;
-    font-size: 80%;
   }
 
   svg {
@@ -17,5 +16,8 @@
     }
   }
   .offer-icon { margin-right: 5px; }
-  .delete-offer { margin-left: 5px; }
+  .delete-offer {
+    margin-left: 5px;
+    font-size: 120%;
+  }
 }

--- a/app/styles/templates/components/_offer_tags.scss
+++ b/app/styles/templates/components/_offer_tags.scss
@@ -4,6 +4,7 @@
   margin:3px;
   border-radius: 10px;
   border: 1px solid #466082;
+  color: white;
 
   @media #{$small-only} {
     padding: 2%;

--- a/app/styles/templates/components/_offer_tags.scss
+++ b/app/styles/templates/components/_offer_tags.scss
@@ -1,70 +1,15 @@
 .offer-tag {
   display: inline-block;
+  padding:1%;
+  margin:3px;
+  border-radius: 5%;
   border: 1px solid #466082;
-  height: 30px;
-  border-radius: 10%;
-  width: auto;
-  margin-left: 0.6em;
-  padding-right: 1em;
-  padding-left: 0.3em;
-}
-
-.offer-detail {
-  font-size: 0.8em;
-  padding-top: 4% !important;
-  display: inline-flex;
-
-  svg {
-    margin-top: 8%;
-    font-size: 0.9rem;
-  }
-  @media #{$small-only} {
-    svg {
-      margin-left: 10%;
-      margin-top: 3%;
-      font-size: 0.9rem;
-    }
-  }
-}
-
-.remove-button{
-  border-radius: inherit;
-  border-left: solid 1px;
-  padding-right: 3%;
-}
-
-.offer-name {
-  padding-left: 5%;
-  margin-left: 8%;
-  margin-top: 5%;
-  font-size: 0.8rem;
 
   @media #{$small-only} {
-    padding-left: 20%;
-    margin-left: 5%;
-    padding-right: 20%;
-  }
-}
-
-.offer-tag-detail {
-  margin-left: 5%;
-  margin-top: -5%;
-  font-size: 0.8rem !important;
-  display: block;
-
-  @media #{$medium-only}{
-    margin-left: 5%;
-    margin-top: -5%;
+    padding: 2%;
   }
 
-  @media #{$small-only} {
-    margin-left: 10%;
-    margin-top: -10%;
-  }
-}
-
-.donations &.remove-button {
-  @media #{$small-only} {
-    padding-top: 9% !important;
-  }
+  svg { font-size: 120%; }
+  .offer-icon { margin-right: 5px; }
+  .delete-offer { margin-left: 5px; }
 }

--- a/app/styles/templates/components/goodcity/_search_overlay.scss
+++ b/app/styles/templates/components/goodcity/_search_overlay.scss
@@ -1,5 +1,45 @@
 .cmp.search-overlay {
   .main-container {
+
+    .search-container {
+      display: flex;
+      align-items: stretch;
+
+      .close-overlay {
+        flex-grow: 1;
+        text-align: center;
+      }
+
+      .search-overlay {
+        flex-grow: 8;
+      }
+
+      .scanner {
+        height: 10px;
+        flex-grow: 1;
+      }
+
+      .scan-button {
+        @media #{$small-only} {
+          float: left;
+        }
+        button {
+          background: none;
+          border: none;
+          padding-bottom: 2rem;
+          margin-bottom: 0;
+
+          i {
+            font-size: 1.8rem;
+            margin-top: -0.4rem;
+            color: #a3aab6;
+            padding-right: 0.5rem;
+          }
+        }
+      }
+
+    }
+
     margin: 0 auto;
     max-width: 768px;
 
@@ -32,29 +72,6 @@
 
           @media #{$small-only} {
             width: 95%;
-          }
-        }
-      }
-
-      .scanner {
-        height: 10px;
-      }
-
-      .scan-button {
-        @media #{$small-only} {
-          float: left;
-        }
-        button {
-          background: none;
-          border: none;
-          padding-bottom: 2rem;
-          margin-bottom: 0;
-
-          i {
-            font-size: 1.8rem;
-            margin-top: -0.4rem;
-            color: #a3aab6;
-            padding-right: 0.5rem;
           }
         }
       }

--- a/app/styles/templates/items/_detail.scss
+++ b/app/styles/templates/items/_detail.scss
@@ -325,6 +325,11 @@
   }
 
   .detail-section {
+    .offer-tags {
+      svg {
+        padding-top: 1%;
+      }
+    }
     padding-bottom: 0.5rem;
     font-size: 0.8rem;
 

--- a/app/styles/templates/items/_new.scss
+++ b/app/styles/templates/items/_new.scss
@@ -284,7 +284,9 @@
   }
 
   .donations{
-    padding-top: 1%;
+    svg {
+      padding-top: 1%;
+    }
   }
 
   .form-footer {

--- a/app/styles/templates/items/_new.scss
+++ b/app/styles/templates/items/_new.scss
@@ -279,9 +279,12 @@
   }
 
   .weight,
-  .donations,
   .publish {
     float: left !important;
+  }
+
+  .donations{
+    padding-top: 1%;
   }
 
   .form-footer {

--- a/app/templates/components/goodcity/offers-search-overlay.hbs
+++ b/app/templates/components/goodcity/offers-search-overlay.hbs
@@ -13,8 +13,8 @@
             placeholder=(t "search_min")
             value=searchText }}
 
-          {{#if hasSearchText}}
-            <i class="pinned-right" {{action "clearSearch"}}>{{fa-icon 'times-circle' size='lg'}}</i>
+          {{#if searchText}}
+            <i class="pinned-right" {{action (mut searchText "")}}>{{fa-icon 'times-circle' size='lg'}}</i>
           {{/if}}
         </div>
         {{#if isMobileApp}}

--- a/app/templates/components/goodcity/offers-search-overlay.hbs
+++ b/app/templates/components/goodcity/offers-search-overlay.hbs
@@ -1,12 +1,11 @@
 <div class="cmp orders search-overlay">
   {{#popup-overlay open=open}}
     <div class="main-container">
-      <div class="row search-field">
-        <div class="icon-holder small-1 medium-1 columns">
+      <div class="search-field search-container">
+        <div class="icon-holder close-overlay">
           <i {{action "closeOverlay"}} class="back_icon" aria-hidden="true">{{fa-icon 'times' size='lg'}}</i>
         </div>
-
-        <div class="input-holder small-9 medium-9 columns offer-search">
+        <div class="input-holder search-overlay">
           {{focus-textfield
             name="searchText"
             id=uuid
@@ -18,7 +17,7 @@
           {{/if}}
         </div>
         {{#if isMobileApp}}
-          <div class="small-1 medium-2 columns scan-button scanner">
+          <div class="scan-button scanner">
             {{scan-barcode-button onScanComplete=(action "setScannedSearchText")}}
           </div>
         {{/if}}

--- a/app/templates/components/offer-tag.hbs
+++ b/app/templates/components/offer-tag.hbs
@@ -1,20 +1,10 @@
-<div class="row">
-  <div class="small-9 columns offer-detail">
-    {{#if offer.company}}
-      {{fa-icon 'building'}}
-      <span class="offer-name">
-      {{offer.company.name}}
-      </span>
-    {{else}}
-      {{fa-icon 'user'}}
-      <span class="offer-name">
-        {{offer.id}}
-      </span>
-    {{/if}}
-  </div>
-  {{#if isPackageOffer}}
-    <div class="small-3 columns remove-button">
-      <span class="delete-offer" {{action "removeOffer" offer}}>{{fa-icon 'times' size="lg"}}</span>
-    </div>
-  {{/if}}
-</div>
+{{#if offer.company}}
+  {{fa-icon 'building' class='offer-icon'}}
+  {{offer.company.name}}
+{{else}}
+  {{fa-icon 'user' class='offer-icon'}}
+  {{offer.id}}
+{{/if}}
+{{#if isPackageOffer}}
+  <span {{action "removeOffer" offer}}>{{fa-icon 'times' size="lg" class="delete-offer"}}</span>
+{{/if}}

--- a/app/templates/items/detail/tabs/_item_detail.hbs
+++ b/app/templates/items/detail/tabs/_item_detail.hbs
@@ -130,10 +130,10 @@
         <div class="columns small-3">
           <span class='input_text'>Offers</span>
         </div>
-        <div class="columns small-9 value last">
-          <div {{action 'addOffer'}}>
+        <div class="columns small-9 value last offer-tags">
+          <span {{action 'addOffer'}}>
             {{fa-icon 'plus-square'  size='2x'}}
-          </div>
+          </span>
           <span class="offer-tag-detail">
             {{#if item.offer}}
               {{offer-tag


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2863

### What does this PR do?
Fixed following:
- When creating an item/box/pallet, if the browser's back button is used or if the item/box/pallet is cancelled, any previously selected users will remain when creating a new item/box/pallet. (Creating the item/box/pallet will remove all users)
- On the iPad, when scanning an invalid barcode for the first time the app is opened, the 'null is not an object (evaluating 'this.get("searchText").length')' pop-up message appeared.
-On the Pixel after adding a user, if another field is selected then the size of the user will increase.
- Scanning barcodes doesn't work for me at all. The first time a barcode is scanned there is an error message (as mentioned by Tim Walton), and after that nothing happens when scanning.
- When using a mobile device, if there is one valid result for any search term, the result is automatically selected and there is no confirmation modal (requirement in ticket description).

### Impacted Areas
Item creation screen
Item detail screen


### Screenshots
![Screenshot 2020-02-26 at 12 12 00 PM](https://user-images.githubusercontent.com/37627094/75318811-50f5a700-5891-11ea-822d-daf06df4aba3.png)
![Screenshot 2020-02-26 at 12 12 11 PM](https://user-images.githubusercontent.com/37627094/75318816-54892e00-5891-11ea-8a4b-388cfcc6a657.png)
