### PR TITLE
FIX=> Catch and Show error on modal on cancelling dispatch order

### DIFF
--- a/app/controllers/orders/detail.js
+++ b/app/controllers/orders/detail.js
@@ -5,7 +5,7 @@ import GoodcityController from "../goodcity_controller";
 import SearchMixin from "stock/mixins/search_resource";
 import _ from "lodash";
 const { getOwner } = Ember;
-import AsyncMixin from "../../mixins/async";
+import AsyncMixin, { ERROR_STRATEGIES } from "stock/mixins/async";
 
 export default GoodcityController.extend(AsyncMixin, SearchMixin, {
   backLinkPath: "",
@@ -210,7 +210,8 @@ export default GoodcityController.extend(AsyncMixin, SearchMixin, {
             this.setProperties({
               otherCancellationReason: ""
             });
-          })
+          }),
+        ERROR_STRATEGIES.MODAL
       );
     },
 


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2931

### What does this PR do?

BUG: On cancelling order with dispatch orders_packages throws error but it was not displayed. This PR catches that error and show on modal.

### Screenshots
![Screenshot 2020-02-26 at 4 01 18 PM](https://user-images.githubusercontent.com/37627094/75336495-43501980-58b1-11ea-8ace-caf9bd95aaf7.png)
