### PR TITLE
GCW-3071 Button is working and displayed Stock: The 'x' button to clear the offer search field is displayed in the wrong place fix

### DIFF
--- a/app/styles/templates/components/goodcity/_search_overlay.scss
+++ b/app/styles/templates/components/goodcity/_search_overlay.scss
@@ -94,8 +94,17 @@
 
       .pinned-right {
         position: absolute;
-        top: 1.4rem;
-        right: 2rem;
+        right: 2.5%;
+        top: 0.93rem;
+        color: $black;
+        font-size: 1.2rem;
+        cursor: pointer;
+
+        @media #{$small-only} {
+          font-size: 1.2rem;
+          padding: 0.5rem 0.5rem;
+          top: 0.5rem;
+        }
       }
     }
 

--- a/app/templates/components/goodcity/offers-search-overlay.hbs
+++ b/app/templates/components/goodcity/offers-search-overlay.hbs
@@ -6,21 +6,24 @@
           <i {{action "closeOverlay"}} class="back_icon" aria-hidden="true">{{fa-icon 'times' size='lg'}}</i>
         </div>
         <div class="input-holder search-overlay">
-          {{focus-textfield
-            name="searchText"
-            id=uuid
-            placeholder=(t "search_min")
-            value=searchText }}
-
-          {{#if searchText}}
-            <i class="pinned-right" {{action 'clearSearch'}}>{{fa-icon 'times-circle' size='lg'}}</i>
-          {{/if}}
-        </div>
-        {{#if isMobileApp}}
-          <div class="scan-button scanner">
-            {{scan-barcode-button onScanComplete=(action "setScannedSearchText")}}
+          <div class="row">
+            <div class="small-10 columns">
+              {{focus-textfield
+                name="searchText"
+                id=uuid
+                placeholder=(t "search_min")
+                value=searchText }}
+              {{#if searchText}}
+                <i class="pinned-right" {{action 'clearSearch'}}>{{fa-icon 'times-circle'}}</i>
+              {{/if}}
+            </div>
+            {{#if isMobileApp}}
+              <div class="small-2 columns scan-button scanner">
+                {{scan-barcode-button onScanComplete=(action "setScannedSearchText")}}
+              </div>
+            {{/if}}
           </div>
-        {{/if}}
+        </div>
       </div>
 
       <section class="main-section orders_search_result search_result">

--- a/app/templates/components/goodcity/offers-search-overlay.hbs
+++ b/app/templates/components/goodcity/offers-search-overlay.hbs
@@ -7,7 +7,7 @@
         </div>
         <div class="input-holder search-overlay">
           <div class="row">
-            <div class="small-10 columns">
+            <div class="small-10 large-12 columns">
               {{focus-textfield
                 name="searchText"
                 id=uuid

--- a/app/templates/components/goodcity/offers-search-overlay.hbs
+++ b/app/templates/components/goodcity/offers-search-overlay.hbs
@@ -7,7 +7,7 @@
         </div>
         <div class="input-holder search-overlay">
           <div class="row">
-            <div class="small-10 large-12 columns">
+            <div class="small-10 medium-10 large-12 columns">
               {{focus-textfield
                 name="searchText"
                 id=uuid
@@ -18,7 +18,7 @@
               {{/if}}
             </div>
             {{#if isMobileApp}}
-              <div class="small-2 columns scan-button scanner">
+              <div class="small-2 medium-2 columns scan-button scanner">
                 {{scan-barcode-button onScanComplete=(action "setScannedSearchText")}}
               </div>
             {{/if}}


### PR DESCRIPTION
### Ticket Link: 
https://jira.crossroads.org.hk/browse/GCW-3071

### What does this PR do?

Displays the X in correct place both in mobile as well as web app
![Screen Shot 2020-03-04 at 5 47 22 PM](https://user-images.githubusercontent.com/60003954/75880010-7e6ac380-5e42-11ea-808a-417758dbc656.png)
![Screen Shot 2020-03-04 at 5 48 11 PM](https://user-images.githubusercontent.com/60003954/75880038-86c2fe80-5e42-11ea-8f9e-ec5f93389624.png)




### Screenshots



