### PR TITLE
GCW-3042 fix dispatch icon on item detail screen

### DIFF
--- a/app/templates/items/detail.hbs
+++ b/app/templates/items/detail.hbs
@@ -38,11 +38,11 @@
           {{#if (is-and item.hasOneDesignatedPackage (is-not model.hasAllPackagesDispatched))}}
             <div class="{{unless item.hasOneDesignatedPackage 'disabled'}}">
               {{#if (is-and model.isSingletonItem model.designation.isGoodCityOrder)}}
-                <div class="no-avatar">
-                  <a href="#" {{action 'dispatchOrdersPackagePopUp' model model.firstDesignatedOrdersPackage.id}} >
+                {{#link-to 'items.detail.publishing' model.id tagName='span' href=false}}
+                  <span class="no-avatar">
                     <i class="item-menu">{{fa-icon 'ship'}}</i>
-                  </a>
-                </div>
+                  </span>
+                {{/link-to}}
               {{/if}}
             </div>
           {{/if}}


### PR DESCRIPTION
### Ticket Link: 

**https://jira.crossroads.org.hk/browse/GCW-3042**

### What does this PR do?

BUG: Fixes dispatch icon on items details screen

`dispatchOrdersPackagePopUp` action was called onClick, but nothing was handled in the controller for that action. 

Removed it completely and it will now work as the designate icon.
i.e. Transition to publishing page, and let the user perform operations.