### PR TITLE
FIX=> wrong offers received duration on offers search

### DIFF
--- a/app/models/offer.js
+++ b/app/models/offer.js
@@ -9,5 +9,6 @@ export default DS.Model.extend({
   companyId: attr("number"),
   createdById: attr("string"),
   company: belongsTo("company", { async: false }),
-  createdBy: belongsTo("user", { async: false })
+  createdBy: belongsTo("user", { async: false }),
+  receivedAt: attr("date")
 });


### PR DESCRIPTION
This PR is for displaying correct received duration time on offers-search overlay.
Issue: It was showing "few seconds ago" duration for all offers on offers-search overlay.

Reason for issue:  `received_at` field was not coming in `offer` model response.

Please review this PR.