### PR TITLE
Remove quantity field

### DIFF
--- a/app/components/goodcity/orders-package-block.js
+++ b/app/components/goodcity/orders-package-block.js
@@ -113,7 +113,8 @@ export default Ember.Component.extend(AsyncMixin, DispatchActions, {
   selectQuantity() {
     const deferred = Ember.RSVP.defer();
     const maxQuantity =
-      this.get("orderPkg.quantity") + this.get("orderPkg.item.availableQty");
+      this.get("orderPkg.quantity") +
+      this.get("orderPkg.item.availableQuantity");
 
     this.set(
       "designationQty",

--- a/app/components/item-options-list.js
+++ b/app/components/item-options-list.js
@@ -3,7 +3,6 @@ import Ember from "ember";
 export default Ember.Component.extend({
   hidden: true,
   item: null,
-  designateFullSet: Ember.computed.localStorage(),
 
   toggleItemClass() {
     var item = this.get("item");

--- a/app/components/quantity-chooser.js
+++ b/app/components/quantity-chooser.js
@@ -52,7 +52,7 @@ export default Ember.Component.extend({
     splitItems() {
       const value = this.elementValue();
       let item = this.get("item");
-      if (+value < 1 || +value >= +item.get("quantity")) {
+      if (+value < 1 || +value >= +item.get("availableQuantity")) {
         this.set("showErrorMessage", true);
         return false;
       }

--- a/app/components/quantity-chooser.js
+++ b/app/components/quantity-chooser.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
-import AjaxPromise from 'stock/utils/ajax-promise';
+import Ember from "ember";
+import AjaxPromise from "stock/utils/ajax-promise";
 const { getOwner } = Ember;
 
 export default Ember.Component.extend({
@@ -9,36 +9,39 @@ export default Ember.Component.extend({
   showErrorMessage: false,
 
   didInsertElement() {
-    this.set('displayChooseQtyOverlay', false);
-    this.set('showErrorMessage', false);
+    this.set("displayChooseQtyOverlay", false);
+    this.set("showErrorMessage", false);
   },
 
   resetValue() {
-    Ember.$('#qtySplitter').val(1);
+    Ember.$("#qtySplitter").val(1);
   },
 
   elementValue() {
-    return Ember.$('#qtySplitter').val();
+    return Ember.$("#qtySplitter").val();
   },
 
   setValueIfValid(value, isValidValue) {
-    if(isValidValue) {
-      this.set('showErrorMessage', false);
-      Ember.$('#qtySplitter').val(value);
+    if (isValidValue) {
+      this.set("showErrorMessage", false);
+      Ember.$("#qtySplitter").val(value);
     } else {
-      this.set('showErrorMessage', true);
+      this.set("showErrorMessage", true);
     }
   },
 
   actions: {
     resetValueAndToggleOverlay() {
       this.resetValue();
-      this.toggleProperty('displayChooseQtyOverlay');
+      this.toggleProperty("displayChooseQtyOverlay");
     },
 
     incrementQty() {
       let incrementedValue = +this.elementValue() + 1;
-      this.setValueIfValid(incrementedValue, incrementedValue < +this.get("item.quantity"));
+      this.setValueIfValid(
+        incrementedValue,
+        incrementedValue < +this.get("item.availableQuantity")
+      );
     },
 
     decrementQty() {
@@ -49,24 +52,32 @@ export default Ember.Component.extend({
     splitItems() {
       const value = this.elementValue();
       let item = this.get("item");
-      if(+value < 1 || +value >= +item.get("quantity")) {
+      if (+value < 1 || +value >= +item.get("quantity")) {
         this.set("showErrorMessage", true);
         return false;
       }
       this.set("showErrorMessage", false);
-      let loadingView = getOwner(this).lookup('component:loading').append();
-      new AjaxPromise(`/items/${item.id}/split_item`, "PUT", this.get('session.authToken'), { package: { quantity: value } })
+      let loadingView = getOwner(this)
+        .lookup("component:loading")
+        .append();
+      new AjaxPromise(
+        `/items/${item.id}/split_item`,
+        "PUT",
+        this.get("session.authToken"),
+        { package: { quantity: value } }
+      )
         .then(data => {
           this.get("store").pushPayload(data);
-        }).catch((error) => {
-            if(error.status === 422){
-              var errors = Ember.$.parseJSON(error.responseText).errors;
-              this.get("messageBox").alert(errors);
-            }
-          })
+        })
+        .catch(error => {
+          if (error.status === 422) {
+            var errors = Ember.$.parseJSON(error.responseText).errors;
+            this.get("messageBox").alert(errors);
+          }
+        })
         .finally(() => {
           this.resetValue();
-          this.set('displayChooseQtyOverlay', false);
+          this.set("displayChooseQtyOverlay", false);
           loadingView.destroy();
         });
     }

--- a/app/controllers/items/detail.js
+++ b/app/controllers/items/detail.js
@@ -133,14 +133,14 @@ export default GoodcityController.extend(
 
     allowPublish: Ember.computed(
       "model.isSingletonItem",
-      "model.availableQty",
+      "model.availableQuantity",
       "isBoxOrPallet",
       function() {
         if (this.get("isBoxOrPallet")) {
           return false;
         }
 
-        const qty = this.get("model.availableQty");
+        const qty = this.get("model.availableQuantity");
         if (this.get("settings.onlyPublishSingletons")) {
           return qty === 1;
         }

--- a/app/controllers/items/detail.js
+++ b/app/controllers/items/detail.js
@@ -47,7 +47,6 @@ export default GoodcityController.extend(
     packageService: Ember.inject.service(),
     locationService: Ember.inject.service(),
     displayScanner: false,
-    designateFullSet: Ember.computed.localStorage(),
     callOrderObserver: false,
     showSetList: false,
     hideDetailsLink: true,

--- a/app/mixins/designation_actions.js
+++ b/app/mixins/designation_actions.js
@@ -43,7 +43,7 @@ export default Ember.Mixin.create(AsyncMixin, {
     }
 
     const maxQuantity =
-      pkg.get("availableQty") + this.alreadyDesignatedQuantity(pkg, order);
+      pkg.get("availableQuantity") + this.alreadyDesignatedQuantity(pkg, order);
 
     this.set("designatableQuantity", maxQuantity);
     if (!this.get("designationQty")) {

--- a/app/mixins/dispatch_actions.js
+++ b/app/mixins/dispatch_actions.js
@@ -47,10 +47,10 @@ export default Ember.Mixin.create(AsyncMixin, {
     }
 
     const pkg = ordPkg.get("item");
-    const pkgLocation = pkg.get("packagesLocations").findBy("location", loc);
-    const availableQty = pkgLocation ? pkgLocation.get("quantity") : 0;
-
-    const maxQuantity = Math.min(availableQty, ordPkg.get("undispatchedQty"));
+    const maxQuantity = Math.min(
+      pkg.get("onHandQuantity"),
+      ordPkg.get("undispatchedQty")
+    );
 
     this.set("dispatchableQuantity", maxQuantity);
     if (!this.get("dispatchQty") || this.get("dispatchQty") > maxQuantity) {

--- a/app/models/item.js
+++ b/app/models/item.js
@@ -91,7 +91,6 @@ export default cloudinaryUrl.extend({
   updatedAt: attr("date"),
 
   imageUrl: Ember.computed.alias("image.imageUrl"),
-  designateFullSet: Ember.computed.localStorage(),
 
   storageTypeName: Ember.computed.alias("storageType.name"),
 
@@ -313,20 +312,6 @@ export default cloudinaryUrl.extend({
       return orderPackages;
     }
   ),
-
-  minSetQty: Ember.computed("setItem.items", function() {
-    if (this.get("isSet") && this.get("designateFullSet")) {
-      var setItems = this.get("setItem.items");
-      var minQty = setItems.canonicalState[0]._data.quantity;
-      setItems.canonicalState.forEach(record => {
-        var qty = record._data.quantity;
-        if (qty < minQty) {
-          minQty = qty;
-        }
-      });
-      return minQty;
-    }
-  }),
 
   isSingletonItem: Ember.computed("quantity", function() {
     return this.get("receivedQuantity") === 1;

--- a/app/models/item.js
+++ b/app/models/item.js
@@ -128,9 +128,7 @@ export default cloudinaryUrl.extend({
     }
   ),
 
-  isAvailable: Ember.computed("availableQuantity", function() {
-    return this.get("availableQuantity") > 0;
-  }),
+  isAvailable: Ember.computed.bool("availableQuantity"),
 
   isUnavailable: Ember.computed.not("isAvailable"),
 

--- a/app/models/orders_package.js
+++ b/app/models/orders_package.js
@@ -22,15 +22,10 @@ export default Model.extend({
   isDesignated: Ember.computed.equal("state", "designated"),
   isCancelled: Ember.computed.equal("state", "cancelled"),
 
-  availableQty: Ember.computed.alias("quantity"),
   isSingleQuantity: Ember.computed.equal("quantity", 1),
 
   undispatchedQty: Ember.computed("quantity", "dispatchedQuantity", function() {
     return this.get("quantity") - this.get("dispatchedQuantity");
-  }),
-
-  qtyToModify: Ember.computed("quantity", "item.quantity", function() {
-    return this.get("quantity") + this.get("item.quantity");
   }),
 
   orderCode: Ember.computed("designation", function() {

--- a/app/models/set_item.js
+++ b/app/models/set_item.js
@@ -58,13 +58,6 @@ export default Model.extend({
     }
   ),
 
-  hasZeroQty: Ember.computed("items.@each.ordersPackages", function() {
-    var zeroQtyItem = this.get("items").find(
-      record => record.get("quantity") === 0
-    );
-    return !Boolean(zeroQtyItem);
-  }),
-
   hasSingleDesignation: Ember.computed(
     "items.@each.ordersPackages",
     function() {

--- a/app/models/set_item.js
+++ b/app/models/set_item.js
@@ -132,6 +132,6 @@ export default Model.extend({
   ),
 
   canBeMoved: Ember.computed("items.@each.hasBoxPallet", function() {
-    return this.get("items").filterBy("hasBoxPallet", true).length === 0;
+    return this.get("items").filterBy("hasBoxPallet").length === 0;
   })
 });

--- a/app/models/set_item.js
+++ b/app/models/set_item.js
@@ -1,105 +1,144 @@
-import attr from 'ember-data/attr';
-import { belongsTo, hasMany } from 'ember-data/relationships';
-import Model from 'ember-data/model';
-import Ember from 'ember';
+import attr from "ember-data/attr";
+import { belongsTo, hasMany } from "ember-data/relationships";
+import Model from "ember-data/model";
+import Ember from "ember";
 
 export default Model.extend({
-
-  description: attr('string'),
-  code:        belongsTo('code', { async: false }),
-  items:       hasMany('item', { async: false }),
+  description: attr("string"),
+  code: belongsTo("code", { async: false }),
+  items: hasMany("item", { async: false }),
   designatedSetItemOrderPackages: [],
 
-  multiQuantitySet: Ember.computed('items.@each.quantity', function() {
-    return this.get("items").rejectBy('quantity', 1).length > 0;
+  multiQuantitySet: Ember.computed("items.@each.availableQuantity", function() {
+    return this.get("items").rejectBy("availableQuantity", 1).length > 0;
   }),
 
-  allDesignated: Ember.computed('items.@each.designation', function() {
-    return this.get("items").filterBy('designation', null).length === 0;
+  allDesignated: Ember.computed("items.@each.designation", function() {
+    return this.get("items").filterBy("designation", null).length === 0;
   }),
 
-  sortedItems: Ember.computed('items', function() {
-    return this.get("items").sortBy('id');
+  sortedItems: Ember.computed("items", function() {
+    return this.get("items").sortBy("id");
   }),
 
-  allDispatched: Ember.computed('items.@each.isDispatched', function() {
-    return this.get("items").filterBy('isDispatched', false).length === 0;
+  allDispatched: Ember.computed("items.@each.isDispatched", function() {
+    return this.get("items").filterBy("isDispatched", false).length === 0;
   }),
 
-  designatedItems: Ember.computed('items.@each.designation', function() {
-    return this.get("items").rejectBy('designation', null);
+  designatedItems: Ember.computed("items.@each.designation", function() {
+    return this.get("items").rejectBy("designation", null);
   }),
 
-  designations: Ember.computed("items.@each.orderCode", "allDesignated", function() {
-    var designatedPackages = [];
-    this.get("designatedSetItemOrderPackages").forEach(designationId => {
-      designatedPackages.push(this.store.peekRecord('designation', designationId));
-    });
-    return designatedPackages;
-  }),
-
-  shareSingleDesignation: Ember.computed("items.@each.orderCode", "allDesignated", function() {
-    if(this.get("allDesignated")) {
-      return this.get("items").map(a => a.get('orderCode')).uniq().length === 1;
+  designations: Ember.computed(
+    "items.@each.orderCode",
+    "allDesignated",
+    function() {
+      var designatedPackages = [];
+      this.get("designatedSetItemOrderPackages").forEach(designationId => {
+        designatedPackages.push(
+          this.store.peekRecord("designation", designationId)
+        );
+      });
+      return designatedPackages;
     }
-    return false;
-  }),
+  ),
+
+  shareSingleDesignation: Ember.computed(
+    "items.@each.orderCode",
+    "allDesignated",
+    function() {
+      if (this.get("allDesignated")) {
+        return (
+          this.get("items")
+            .map(a => a.get("orderCode"))
+            .uniq().length === 1
+        );
+      }
+      return false;
+    }
+  ),
 
   hasZeroQty: Ember.computed("items.@each.ordersPackages", function() {
-    var zeroQtyItem = this.get("items").find(record => record.get("quantity") === 0);
+    var zeroQtyItem = this.get("items").find(
+      record => record.get("quantity") === 0
+    );
     return !Boolean(zeroQtyItem);
   }),
 
-  hasSingleDesignation: Ember.computed("items.@each.ordersPackages", function() {
-    var lessThanOneDesignation = true;
-    this.get("items").forEach(record => {
-      var designatedOrderPackages = record.get("ordersPackages").filterBy("state", "designated");
-      if(designatedOrderPackages.get("length") > 1 || designatedOrderPackages.get("length") === 0) {
-        lessThanOneDesignation = false;
-      }
-    });
-    return lessThanOneDesignation;
-  }),
-
-  designatedAndDispatchedOrdersPackages: Ember.computed("items.@each.ordersPackages", function() {
-    var designatedAndDispatchedPackages = [];
-    this.get("items").forEach(record => {
-      var orderPackages = record.get("ordersPackages").filterBy("quantity");
-      orderPackages.forEach(record => {
-        if(record && record.get("state") !== "cancelled") {
-          designatedAndDispatchedPackages.push(record);
+  hasSingleDesignation: Ember.computed(
+    "items.@each.ordersPackages",
+    function() {
+      var lessThanOneDesignation = true;
+      this.get("items").forEach(record => {
+        var designatedOrderPackages = record
+          .get("ordersPackages")
+          .filterBy("state", "designated");
+        if (
+          designatedOrderPackages.get("length") > 1 ||
+          designatedOrderPackages.get("length") === 0
+        ) {
+          lessThanOneDesignation = false;
         }
       });
-    });
-    return designatedAndDispatchedPackages;
-  }),
+      return lessThanOneDesignation;
+    }
+  ),
 
-  setItemOrdersPackages: Ember.computed("items.@each.ordersPackages", function() {
-    return this.get('designatedAndDispatchedOrdersPackages.length');
-  }),
+  designatedAndDispatchedOrdersPackages: Ember.computed(
+    "items.@each.ordersPackages",
+    function() {
+      var designatedAndDispatchedPackages = [];
+      this.get("items").forEach(record => {
+        var orderPackages = record.get("ordersPackages").filterBy("quantity");
+        orderPackages.forEach(record => {
+          if (record && record.get("state") !== "cancelled") {
+            designatedAndDispatchedPackages.push(record);
+          }
+        });
+      });
+      return designatedAndDispatchedPackages;
+    }
+  ),
 
-  hasSameSingleDesignation: Ember.computed("items.@each.ordersPackages", function() {
-    var sameSingleDesignation = true;
-    var designatedPackages = [];
+  setItemOrdersPackages: Ember.computed(
+    "items.@each.ordersPackages",
+    function() {
+      return this.get("designatedAndDispatchedOrdersPackages.length");
+    }
+  ),
 
-    this.get("items").forEach(record => {
-      var designatedOrderPackages = record.get("ordersPackages").filterBy("state", "designated");
-      if(designatedOrderPackages.get("length") === 1) {
-        designatedPackages.push(designatedOrderPackages[0].get("designationId"));
-      }
-    });
+  hasSameSingleDesignation: Ember.computed(
+    "items.@each.ordersPackages",
+    function() {
+      var sameSingleDesignation = true;
+      var designatedPackages = [];
 
-    designatedPackages.forEach(record => {
-      if(record !== designatedPackages[0]) {
-        sameSingleDesignation = false;
-      }
-    });
+      this.get("items").forEach(record => {
+        var designatedOrderPackages = record
+          .get("ordersPackages")
+          .filterBy("state", "designated");
+        if (designatedOrderPackages.get("length") === 1) {
+          designatedPackages.push(
+            designatedOrderPackages[0].get("designationId")
+          );
+        }
+      });
 
-    this.set("designatedSetItemOrderPackages", designatedPackages);
-    return Boolean((designatedPackages.get("length") === this.get("items.length") && sameSingleDesignation));
-  }),
+      designatedPackages.forEach(record => {
+        if (record !== designatedPackages[0]) {
+          sameSingleDesignation = false;
+        }
+      });
 
-  canBeMoved: Ember.computed('items.@each.hasBoxPallet', function() {
-    return this.get("items").filterBy('hasBoxPallet', true).length === 0;
+      this.set("designatedSetItemOrderPackages", designatedPackages);
+      return Boolean(
+        designatedPackages.get("length") === this.get("items.length") &&
+          sameSingleDesignation
+      );
+    }
+  ),
+
+  canBeMoved: Ember.computed("items.@each.hasBoxPallet", function() {
+    return this.get("items").filterBy("hasBoxPallet", true).length === 0;
   })
 });

--- a/app/routes/items/index.js
+++ b/app/routes/items/index.js
@@ -9,7 +9,6 @@ export default AuthorizeRoute.extend({
     searchInput: ""
   },
 
-  designateFullSet: Ember.computed.localStorage(),
   partial_qnty: Ember.computed.localStorage(),
 
   previousPage(transition) {
@@ -40,7 +39,6 @@ export default AuthorizeRoute.extend({
 
   setupController(controller, model = {}) {
     this._super(controller, model);
-    this.set("designateFullSet", false);
     this.set("partial_qnty", 0);
     controller.set("itemSetId", this.paramsFor("items.index").itemSetId);
     controller.on();
@@ -49,7 +47,6 @@ export default AuthorizeRoute.extend({
 
   afterModel() {
     this.set("partial_qnty", 0);
-    this.set("designateFullSet", false);
   },
 
   resetController(controller, isExiting) {

--- a/app/templates/components/goodcity/add-item-overlay.hbs
+++ b/app/templates/components/goodcity/add-item-overlay.hbs
@@ -22,15 +22,15 @@
             <div class="tab end large">
               <div class="sub-tabs">
                 <div class="icon-holder">{{fa-icon 'paper-plane' }}</div>
-                <div class="text-holder">{{pkg.totalDispatchedQty}}</div>
+                <div class="text-holder">{{pkg.dispatchedQuantity}}</div>
               </div>
               <div class="sub-tabs">
                 <div class="icon-holder">{{fa-icon 'shopping-basket' }}</div>
-                <div class="text-holder">{{pkg.totalDesignatedQty }}</div>
+                <div class="text-holder">{{pkg.designatedQuantity }}</div>
               </div>
               <div class="sub-tabs">
                 <div class="icon-holder">{{fa-icon 'eye' }}</div>
-                <div class="text-holder">{{pkg.availableQty}}</div>
+                <div class="text-holder">{{pkg.availableQuantity}}</div>
               </div>
             </div>
           </div>

--- a/app/templates/items/_item_description.hbs
+++ b/app/templates/items/_item_description.hbs
@@ -2,7 +2,7 @@
   <div class="small-6 large-8 columns name_details">
     <div class="ellipsis name one-line-ellipsis" style="display: inline!important;">{{item.onHandQuantity}} x {{item.code.name}}</div>
     <span class="available-designate-dispatch-count" style="margin-left: 0.25rem;">
-      {{item.onHandQuantity}}/{{item.totalDesignatedQty}}/{{item.totalDispatchedQty}}
+      {{item.onHandQuantity}}/{{item.designatedQuantity}}/{{item.dispatchedQuantity}}
     </span>
     <div class="ellipsis two-line-ellipsis">
       {{item.notes}}

--- a/app/templates/items/detail/_tabs.hbs
+++ b/app/templates/items/detail/_tabs.hbs
@@ -29,15 +29,15 @@
     class="tab publishing divided large {{if (is-equal tabName 'publishing') 'selected'}}">
     <div class="subtab">
       <div class="icon-holder">{{fa-icon 'paper-plane' size="lg"}}</div>
-      <div class="text-holder"> {{ model.totalDispatchedQty }} </div>
+      <div class="text-holder"> {{ model.dispatchedQuantity }} </div>
     </div>
     <div class="subtab">
       <div class="icon-holder">{{fa-icon 'shopping-basket' size="lg"}}</div>
-      <div class="text-holder"> {{ model.totalDesignatedQty }} </div>
+      <div class="text-holder"> {{ model.designatedQuantity }} </div>
     </div>
     <div class="subtab">
       <div class="icon-holder">{{fa-icon (if model.allowWebPublish 'eye' 'eye-slash') size="lg"}}</div>
-      <div class="text-holder"> {{ model.availableQty }} </div>
+      <div class="text-holder"> {{ model.availableQuantity }} </div>
     </div>
   </div>
 </div>

--- a/app/templates/items/detail/tabs/_item_detail.hbs
+++ b/app/templates/items/detail/tabs/_item_detail.hbs
@@ -4,10 +4,10 @@
       <div class="row">
         <div class="columns small-4">{{t "item_details.quantity"}}</div>
         <div class="columns small-3 value item-quantity">
-          {{item.quantity}}
+          {{item.availableQuantity}}
         </div>
         <div class="columns small-5 value">
-          {{#if (is-greater item.quantity 1)}}
+          {{#if (is-greater item.availableQuantity 1)}}
             {{quantity-chooser item=item}}
           {{/if}}
         </div>

--- a/app/templates/items/detail/tabs/location.hbs
+++ b/app/templates/items/detail/tabs/location.hbs
@@ -16,7 +16,7 @@
   {{/each}}
   <div class="row content-row italic">
     <div class="columns small-6">&nbsp;</div>
-    <div class="columns small-2">{{ model.totalDispatchedQty }}</div>
+    <div class="columns small-2">{{ model.dispatchedQuantity }}</div>
     <div class="columns small-2">
       {{t 'item_filters.dispatched' }}
     </div>

--- a/app/templates/items/detail/tabs/publishing.hbs
+++ b/app/templates/items/detail/tabs/publishing.hbs
@@ -6,7 +6,7 @@
       {{else}}
         {{fa-icon 'eye-slash'}}
       {{/if}}
-      {{t 'partial_undesignate.available' }} ({{ model.availableQty }})
+      {{t 'partial_undesignate.available' }} ({{ model.availableQuantity }})
     </div>
     <div class="row action-row">
       <div class="small-6 columns">
@@ -37,11 +37,11 @@
     </div>
     <div class="columns small-4">
       {{fa-icon 'paper-plane'}}
-      {{model.totalDispatchedQty}} {{t 'item_filters.dispatched' }}
+      {{model.dispatchedQuantity}} {{t 'item_filters.dispatched' }}
     </div>
     <div class="columns small-4">
       {{fa-icon 'eye'}}
-      {{model.totalDesignatedQty}} {{t 'item_filters.designated' }}
+      {{model.designatedQuantity}} {{t 'item_filters.designated' }}
     </div>
   </div>
 

--- a/tests/acceptance/split-quantity-of-items-test.js
+++ b/tests/acceptance/split-quantity-of-items-test.js
@@ -1,41 +1,76 @@
-import Ember from 'ember';
-import { module, test } from 'qunit';
-import startApp from '../helpers/start-app';
-import '../factories/orders_package';
-import '../factories/designation';
-import '../factories/item';
-import '../factories/location';
-import FactoryGuy from 'ember-data-factory-guy';
-import { mockFindAll } from 'ember-data-factory-guy';
+import Ember from "ember";
+import { module, test } from "qunit";
+import startApp from "../helpers/start-app";
+import "../factories/orders_package";
+import "../factories/designation";
+import "../factories/item";
+import "../factories/location";
+import FactoryGuy from "ember-data-factory-guy";
+import { mockFindAll } from "ember-data-factory-guy";
 
 var App, pkg, mocks;
 
-module('Acceptance: Split Item Quantity', {
+module("Acceptance: Split Item Quantity", {
   beforeEach: function() {
     App = startApp({}, 2);
     var location = FactoryGuy.make("location");
     var designation = FactoryGuy.make("designation");
     var bookingType = FactoryGuy.make("booking_type");
-    mockFindAll('designation').returns({json: {designations: [designation.toJSON({includeId: true})]}});
-    mockFindAll('location').returns({json: {locations: [location.toJSON({includeId: true})]}});
-    mockFindAll('booking_type').returns({json: {booking_types: [bookingType.toJSON({includeId: true})]}});
-    pkg = FactoryGuy.make("item", { id: 50, state: "submitted" , quantity: 20, height: 10, width: 15, length: 20, notes: "Split quantity test." });
-    var data = {"user_profile": [{"id": 2,"first_name": "David", "last_name": "Dara51", "mobile": "61111111", "user_role_ids": [1]}], "users": [{"id": 2,"first_name": "David", "last_name": "Dara51", "mobile": "61111111"}], "roles": [{"id": 4, "name": "Supervisor"}], "user_roles": [{"id": 1, "user_id": 2, "role_id": 4}]};
+    mockFindAll("designation").returns({
+      json: { designations: [designation.toJSON({ includeId: true })] }
+    });
+    mockFindAll("location").returns({
+      json: { locations: [location.toJSON({ includeId: true })] }
+    });
+    mockFindAll("booking_type").returns({
+      json: { booking_types: [bookingType.toJSON({ includeId: true })] }
+    });
+    pkg = FactoryGuy.make("item", {
+      id: 50,
+      state: "submitted",
+      quantity: 20,
+      height: 10,
+      width: 15,
+      length: 20,
+      notes: "Split quantity test."
+    });
+    var data = {
+      user_profile: [
+        {
+          id: 2,
+          first_name: "David",
+          last_name: "Dara51",
+          mobile: "61111111",
+          user_role_ids: [1]
+        }
+      ],
+      users: [
+        { id: 2, first_name: "David", last_name: "Dara51", mobile: "61111111" }
+      ],
+      roles: [{ id: 4, name: "Supervisor" }],
+      user_roles: [{ id: 1, user_id: 2, role_id: 4 }]
+    };
 
     mocks = [];
     $.mockjaxSettings.matchInRegistrationOrder = false;
     mocks.push(
-      $.mockjax({url:"/api/v1/auth/current_user_profil*", responseText: data }),
-      $.mockjax({url:"/api/v1/orders/summar*", responseText: {
-        "submitted":14,
-        "awaiting_dispatch":1,
-        "dispatching":1,
-        "processing":2,
-        "priority_submitted":14,
-        "priority_dispatching":1,
-        "priority_processing":2,
-        "priority_awaiting_dispatch":1
-      }})
+      $.mockjax({
+        url: "/api/v1/auth/current_user_profil*",
+        responseText: data
+      }),
+      $.mockjax({
+        url: "/api/v1/orders/summar*",
+        responseText: {
+          submitted: 14,
+          awaiting_dispatch: 1,
+          dispatching: 1,
+          processing: 2,
+          priority_submitted: 14,
+          priority_dispatching: 1,
+          priority_processing: 2,
+          priority_awaiting_dispatch: 1
+        }
+      })
     );
   },
   afterEach: function() {
@@ -44,195 +79,330 @@ module('Acceptance: Split Item Quantity', {
     mocks.forEach($.mockjax.clear);
 
     // Stop the app
-    Ember.run(App, 'destroy');
+    Ember.run(App, "destroy");
   }
 });
 
-test("Splitting the Quantity of item", function(assert){
+test("Splitting the Quantity of item", function(assert) {
   assert.expect(1);
-  const updatedPkg = FactoryGuy.make("item", { id: 50, state: "submitted" , quantity: 18, height: 10, width: 15, length: 20, notes: "Update Package."});
+  const updatedPkg = FactoryGuy.make("item", {
+    id: 50,
+    state: "submitted",
+    availableQuantity: 18,
+    height: 10,
+    width: 15,
+    length: 20,
+    notes: "Update Package."
+  });
   mocks.push(
-    $.mockjax({url: '/api/v1/stockit_item*', type: 'GET',
-      status: 200,responseText: {
-        items: [updatedPkg.toJSON({includeId: true})]
+    $.mockjax({
+      url: "/api/v1/stockit_item*",
+      type: "GET",
+      status: 200,
+      responseText: {
+        items: [updatedPkg.toJSON({ includeId: true })]
       }
     })
   );
-  mockFindAll('item').returns({ json: {items: [updatedPkg.toJSON({includeId: true})]}});
+  mockFindAll("item").returns({
+    json: { items: [updatedPkg.toJSON({ includeId: true })] }
+  });
   mocks.push(
-    $.mockjax({ url: `/items/${updatedPkg.id}/split_ite*`,
-      type: 'PUT', status: 200, responseText: updatedPkg })
+    $.mockjax({
+      url: `/items/${updatedPkg.id}/split_ite*`,
+      type: "PUT",
+      status: 200,
+      responseText: updatedPkg
+    })
   );
   visit("/");
-  andThen(function(){
+  andThen(function() {
     visit(`/items/${updatedPkg.id}`);
   });
-  andThen(function(){
-    click('.split-quantity');
+  andThen(function() {
+    click(".split-quantity");
   });
-  andThen(function(){
-    fillIn("#qtySplitter", '2');
+  andThen(function() {
+    fillIn("#qtySplitter", "2");
   });
-  andThen(function(){
-    click('.split-item-btn');
+  andThen(function() {
+    click(".split-item-btn");
   });
-  andThen(function(){
-    assert.equal(+Ember.$('.item-quantity').text().trim(), 18);
+  andThen(function() {
+    assert.equal(
+      +Ember.$(".item-quantity")
+        .text()
+        .trim(),
+      18
+    );
   });
 });
 
-test("Testing upper limit validation for splitting the quantity", function(assert){
-  const updatedPkg = FactoryGuy.make("item", { id: 50, state: "submitted" , quantity: 2, height: 10, width: 15, length: 20, notes: "Update Package."});
+test("Testing upper limit validation for splitting the quantity", function(assert) {
+  const updatedPkg = FactoryGuy.make("item", {
+    id: 50,
+    state: "submitted",
+    availableQuantity: 2,
+    height: 10,
+    width: 15,
+    length: 20,
+    notes: "Update Package."
+  });
   mocks.push(
-    $.mockjax({url: '/api/v1/stockit_item*', type: 'GET', status: 200,responseText: {
-      items: [updatedPkg.toJSON({includeId: true})]
+    $.mockjax({
+      url: "/api/v1/stockit_item*",
+      type: "GET",
+      status: 200,
+      responseText: {
+        items: [updatedPkg.toJSON({ includeId: true })]
       }
     })
   );
-  mockFindAll('item').returns({ json: {items: [updatedPkg.toJSON({includeId: true})]}});
+  mockFindAll("item").returns({
+    json: { items: [updatedPkg.toJSON({ includeId: true })] }
+  });
   mocks.push(
-    $.mockjax({ url: `/items/${updatedPkg.id}/split_ite*`,
-    type: 'PUT', status: 200, responseText: updatedPkg })
+    $.mockjax({
+      url: `/items/${updatedPkg.id}/split_ite*`,
+      type: "PUT",
+      status: 200,
+      responseText: updatedPkg
+    })
   );
   assert.expect(1);
   visit("/");
-  andThen(function(){
+  andThen(function() {
     visit(`/items/${updatedPkg.id}`);
   });
-  andThen(function(){
-    click('.split-quantity');
+  andThen(function() {
+    click(".split-quantity");
   });
-  andThen(function(){
-    click('.increment-btn-icon');
+  andThen(function() {
+    click(".increment-btn-icon");
   });
-  andThen(function(){
-    assert.equal(Ember.$('.error-box').text().trim(), "Quantity to split must be at least 1 and less than 2");
+  andThen(function() {
+    assert.equal(
+      Ember.$(".error-box")
+        .text()
+        .trim(),
+      "Quantity to split must be at least 1 and less than 2"
+    );
   });
 });
 
-test("Testing lower limit validation for splitting the quantity", function(assert){
-  const updatedPkg = FactoryGuy.make("item", { id: 50, state: "submitted" , quantity: 2, height: 10, width: 15, length: 20, notes: "Update Package."});
+test("Testing lower limit validation for splitting the quantity", function(assert) {
+  const updatedPkg = FactoryGuy.make("item", {
+    id: 50,
+    state: "submitted",
+    availableQuantity: 2,
+    height: 10,
+    width: 15,
+    length: 20,
+    notes: "Update Package."
+  });
   mocks.push(
-    $.mockjax({url: '/api/v1/stockit_item*', type: 'GET', status: 200,responseText: {
-      items: [updatedPkg.toJSON({includeId: true})]
+    $.mockjax({
+      url: "/api/v1/stockit_item*",
+      type: "GET",
+      status: 200,
+      responseText: {
+        items: [updatedPkg.toJSON({ includeId: true })]
       }
     })
   );
-  mockFindAll('item').returns({ json: {items: [updatedPkg.toJSON({includeId: true})]}});
+  mockFindAll("item").returns({
+    json: { items: [updatedPkg.toJSON({ includeId: true })] }
+  });
   mocks.push(
-    $.mockjax({ url: `/items/${updatedPkg.id}/split_ite*`, type:
-      'PUT', status: 200, responseText: updatedPkg })
+    $.mockjax({
+      url: `/items/${updatedPkg.id}/split_ite*`,
+      type: "PUT",
+      status: 200,
+      responseText: updatedPkg
+    })
   );
   assert.expect(1);
   visit("/");
-  andThen(function(){
+  andThen(function() {
     visit(`/items/${updatedPkg.id}`);
   });
-  andThen(function(){
-    click('.split-quantity');
+  andThen(function() {
+    click(".split-quantity");
   });
-  andThen(function(){
-    click('.decrement-btn-icon');
+  andThen(function() {
+    click(".decrement-btn-icon");
   });
-  andThen(function(){
-    assert.equal(Ember.$('.error-box').text().trim(), "Quantity to split must be at least 1 and less than 2");
+  andThen(function() {
+    assert.equal(
+      Ember.$(".error-box")
+        .text()
+        .trim(),
+      "Quantity to split must be at least 1 and less than 2"
+    );
   });
 });
 
-test("Splitting the Quantity of item, entering wrong quantity(higher than the quantity) should show an error", function(assert){
-  const updatedPkg = FactoryGuy.make("item", { id: 50, state: "submitted" , quantity: 2, height: 10, width: 15, length: 20, notes: "Update Package."});
+test("Splitting the Quantity of item, entering wrong quantity(higher than the quantity) should show an error", function(assert) {
+  const updatedPkg = FactoryGuy.make("item", {
+    id: 50,
+    state: "submitted",
+    availableQuantity: 2,
+    height: 10,
+    width: 15,
+    length: 20,
+    notes: "Update Package."
+  });
   mocks.push(
-    $.mockjax({url: '/api/v1/stockit_item*', type: 'GET', status: 200,responseText: {
-      items: [updatedPkg.toJSON({includeId: true})]
+    $.mockjax({
+      url: "/api/v1/stockit_item*",
+      type: "GET",
+      status: 200,
+      responseText: {
+        items: [updatedPkg.toJSON({ includeId: true })]
       }
     })
   );
-  mockFindAll('item').returns({ json: {items: [updatedPkg.toJSON({includeId: true})]}});
+  mockFindAll("item").returns({
+    json: { items: [updatedPkg.toJSON({ includeId: true })] }
+  });
   mocks.push(
-    $.mockjax({ url: `/items/${updatedPkg.id}/split_ite*`,
-      type: 'PUT', status: 200, responseText: updatedPkg })
+    $.mockjax({
+      url: `/items/${updatedPkg.id}/split_ite*`,
+      type: "PUT",
+      status: 200,
+      responseText: updatedPkg
+    })
   );
   assert.expect(1);
   visit("/");
-  andThen(function(){
+  andThen(function() {
     visit(`/items/${updatedPkg.id}`);
   });
-  andThen(function(){
-    click('.split-quantity');
+  andThen(function() {
+    click(".split-quantity");
   });
-  andThen(function(){
-    fillIn("#qtySplitter", '4');
+  andThen(function() {
+    fillIn("#qtySplitter", "4");
   });
-  andThen(function(){
-    click('.split-item-btn');
+  andThen(function() {
+    click(".split-item-btn");
   });
-  andThen(function(){
-    assert.equal(Ember.$('.error-box').text().trim(), "Quantity to split must be at least 1 and less than 2");
+  andThen(function() {
+    assert.equal(
+      Ember.$(".error-box")
+        .text()
+        .trim(),
+      "Quantity to split must be at least 1 and less than 2"
+    );
   });
 });
 
-test("Splitting the Quantity of item, entering wrong quantity(lower than the quantity) should show an error", function(assert){
+test("Splitting the Quantity of item, entering wrong quantity(lower than the quantity) should show an error", function(assert) {
   assert.expect(1);
-  const updatedPkg = FactoryGuy.make("item", { id: 50, state: "submitted" , quantity: 2, height: 10, width: 15, length: 20, notes: "Update Package."});
+  const updatedPkg = FactoryGuy.make("item", {
+    id: 50,
+    state: "submitted",
+    availableQuantity: 2,
+    height: 10,
+    width: 15,
+    length: 20,
+    notes: "Update Package."
+  });
   mocks.push(
-    $.mockjax({url: '/api/v1/stockit_item*', type: 'GET', status: 200,responseText: {
-      items: [updatedPkg.toJSON({includeId: true})]
+    $.mockjax({
+      url: "/api/v1/stockit_item*",
+      type: "GET",
+      status: 200,
+      responseText: {
+        items: [updatedPkg.toJSON({ includeId: true })]
       }
     })
   );
-  mockFindAll('item').returns({ json: {items: [updatedPkg.toJSON({includeId: true})]}});
+  mockFindAll("item").returns({
+    json: { items: [updatedPkg.toJSON({ includeId: true })] }
+  });
   mocks.push(
-    $.mockjax({ url: `/items/${updatedPkg.id}/split_ite*`, type: 'PUT',
-      status: 200, responseText: updatedPkg })
+    $.mockjax({
+      url: `/items/${updatedPkg.id}/split_ite*`,
+      type: "PUT",
+      status: 200,
+      responseText: updatedPkg
+    })
   );
   visit("/");
-  andThen(function(){
+  andThen(function() {
     visit(`/items/${updatedPkg.id}`);
   });
-  andThen(function(){
-    click('.split-quantity');
+  andThen(function() {
+    click(".split-quantity");
   });
-  andThen(function(){
-    fillIn("#qtySplitter", '0');
+  andThen(function() {
+    fillIn("#qtySplitter", "0");
   });
-  andThen(function(){
-    click('.split-item-btn');
+  andThen(function() {
+    click(".split-item-btn");
   });
-  andThen(function(){
-    assert.equal(Ember.$('.error-box').text().trim(), "Quantity to split must be at least 1 and less than 2");
+  andThen(function() {
+    assert.equal(
+      Ember.$(".error-box")
+        .text()
+        .trim(),
+      "Quantity to split must be at least 1 and less than 2"
+    );
   });
 });
 
-test("Clicking on not now should not split, and quantity should remain as it is", function(assert){
+test("Clicking on not now should not split, and quantity should remain as it is", function(assert) {
   assert.expect(1);
-  const updatedPkg = FactoryGuy.make("item", { id: 50, state: "submitted" , quantity: 20, height: 10, width: 15, length: 20, notes: "Update Package."});
+  const updatedPkg = FactoryGuy.make("item", {
+    id: 50,
+    state: "submitted",
+    availableQuantity: 20,
+    height: 10,
+    width: 15,
+    length: 20,
+    notes: "Update Package."
+  });
   mocks.push(
-    $.mockjax({url: '/api/v1/stockit_item*', type: 'GET',
-      status: 200,responseText: {
-        items: [updatedPkg.toJSON({includeId: true})]
+    $.mockjax({
+      url: "/api/v1/stockit_item*",
+      type: "GET",
+      status: 200,
+      responseText: {
+        items: [updatedPkg.toJSON({ includeId: true })]
       }
     })
   );
-  mockFindAll('item').returns({ json: {items: [updatedPkg.toJSON({includeId: true})]}});
+  mockFindAll("item").returns({
+    json: { items: [updatedPkg.toJSON({ includeId: true })] }
+  });
   mocks.push(
-    $.mockjax({ url: `/items/${updatedPkg.id}/split_ite*`,
-      type: 'PUT', status: 200, responseText: updatedPkg })
+    $.mockjax({
+      url: `/items/${updatedPkg.id}/split_ite*`,
+      type: "PUT",
+      status: 200,
+      responseText: updatedPkg
+    })
   );
   visit("/");
-  andThen(function(){
+  andThen(function() {
     visit(`/items/${updatedPkg.id}`);
   });
-  andThen(function(){
-    click('.split-quantity');
+  andThen(function() {
+    click(".split-quantity");
   });
-  andThen(function(){
-    fillIn("#qtySplitter", '2');
+  andThen(function() {
+    fillIn("#qtySplitter", "2");
   });
-  andThen(function(){
-    click('.dont-split-btn');
+  andThen(function() {
+    click(".dont-split-btn");
   });
-  andThen(function(){
-    assert.equal(+Ember.$('.item-quantity').text().trim(), 20);
+  andThen(function() {
+    assert.equal(
+      +Ember.$(".item-quantity")
+        .text()
+        .trim(),
+      20
+    );
   });
 });
-

--- a/tests/controller/item-details-test.js
+++ b/tests/controller/item-details-test.js
@@ -1,19 +1,18 @@
-import { test, moduleFor } from 'ember-qunit';
+import { test, moduleFor } from "ember-qunit";
 
-moduleFor('controller:items.detail', 'items.detail controller', {
-  needs: ['service:messageBox', 'service:i18n']
+moduleFor("controller:items.detail", "items.detail controller", {
+  needs: ["service:messageBox", "service:i18n"]
 });
 
-test('Checking for default set values', function(assert) {
+test("Checking for default set values", function(assert) {
   assert.expect(6);
 
   var controller = this.subject();
 
-  assert.equal(controller.get('item'), null);
-  assert.equal(controller.get('backLinkPath'), "");
-  assert.equal(controller.get('queryParams')[0], "showDispatchOverlay");
-  assert.equal(controller.get('showDispatchOverlay'), false);
-  assert.equal(controller.get('autoDisplayOverlay'), false);
-  assert.equal(controller.get('displayScanner'), false);
-  // assert.equal(controller.get('designateFullSet'), false);
+  assert.equal(controller.get("item"), null);
+  assert.equal(controller.get("backLinkPath"), "");
+  assert.equal(controller.get("queryParams")[0], "showDispatchOverlay");
+  assert.equal(controller.get("showDispatchOverlay"), false);
+  assert.equal(controller.get("autoDisplayOverlay"), false);
+  assert.equal(controller.get("displayScanner"), false);
 });

--- a/tests/factories/item.js
+++ b/tests/factories/item.js
@@ -1,37 +1,40 @@
-import FactoryGuy from 'ember-data-factory-guy';
-import './designation';
+import FactoryGuy from "ember-data-factory-guy";
+import "./designation";
 
-FactoryGuy.define('item', {
+FactoryGuy.define("item", {
   sequences: {
     id: function(num) {
       return num;
     },
-    inventoryNumber: function (num) {
+    inventoryNumber: function(num) {
       var inventory = 24400 + num;
       return "C" + inventory;
     },
-    itemId: function (num) {
+    itemId: function(num) {
       return num;
     }
   },
   default: {
-    id:               FactoryGuy.generate('id'),
-    inventoryNumber:  "C4234",
-    quantity:         1,
-    createdAt:        '12/01/2016',
-    updatedAt:        '12/01/2016',
-    state:            'submitted',
-    notes:             "Example",
-    length:            10,
-    width:             10,
-    height:            10,
+    id: FactoryGuy.generate("id"),
+    inventoryNumber: "C4234",
+    availableQuantity: 1,
+    onHandQuantity: 1,
+    designatedQuantity: 0,
+    dispatchedQuantity: 0,
+    createdAt: "12/01/2016",
+    updatedAt: "12/01/2016",
+    state: "submitted",
+    notes: "Example",
+    length: 10,
+    width: 10,
+    height: 10,
     allow_web_publish: false,
     receivedQuantity: 1,
-    itemId:            FactoryGuy.generate('itemId'),
-    package_type:      FactoryGuy.belongsTo('package_type'),
-    orders_packages:   FactoryGuy.hasMany('orders_package'),
-    packages_locations:FactoryGuy.hasMany('packages_location'),
-    designation:       FactoryGuy.belongsTo('designation')
+    itemId: FactoryGuy.generate("itemId"),
+    package_type: FactoryGuy.belongsTo("package_type"),
+    orders_packages: FactoryGuy.hasMany("orders_package"),
+    packages_locations: FactoryGuy.hasMany("packages_location"),
+    designation: FactoryGuy.belongsTo("designation")
   }
 });
 

--- a/tests/unit/model/item-test.js
+++ b/tests/unit/model/item-test.js
@@ -13,19 +13,29 @@ moduleForModel("item", "Item Model", {
     "model:packages_location",
     "model:orders_package",
     "model:image",
-    "model:detail"
+    "model:detail",
+    "model:storage_type",
+    "model:offers_package",
+    "model:offer"
   ]
 });
 
 test("check attributes", function(assert) {
-  assert.expect(15);
+  assert.expect(18);
   var model = this.subject();
   var notes = Object.keys(model.toJSON()).indexOf("notes") > -1;
   var grade = Object.keys(model.toJSON()).indexOf("grade") > -1;
   var inventoryNumber =
     Object.keys(model.toJSON()).indexOf("inventoryNumber") > -1;
   var caseNumber = Object.keys(model.toJSON()).indexOf("caseNumber") > -1;
-  var quantity = Object.keys(model.toJSON()).indexOf("quantity") > -1;
+  var onHandQuantity =
+    Object.keys(model.toJSON()).indexOf("onHandQuantity") > -1;
+  var designatedQuantity =
+    Object.keys(model.toJSON()).indexOf("designatedQuantity") > -1;
+  var dispatchedQuantity =
+    Object.keys(model.toJSON()).indexOf("dispatchedQuantity") > -1;
+  var availableQuantity =
+    Object.keys(model.toJSON()).indexOf("availableQuantity") > -1;
   var receivedQuantity =
     Object.keys(model.toJSON()).indexOf("receivedQuantity") > -1;
   var length = Object.keys(model.toJSON()).indexOf("length") > -1;
@@ -43,7 +53,10 @@ test("check attributes", function(assert) {
   assert.ok(grade);
   assert.ok(inventoryNumber);
   assert.ok(caseNumber);
-  assert.ok(quantity);
+  assert.ok(designatedQuantity);
+  assert.ok(onHandQuantity);
+  assert.ok(dispatchedQuantity);
+  assert.ok(availableQuantity);
   assert.ok(receivedQuantity);
   assert.ok(length);
   assert.ok(width);
@@ -243,35 +256,6 @@ test("check orderPackagesMoreThenZeroQty computed property", function(assert) {
     .get("orderPackagesMoreThenZeroQty")
     .getEach("id");
   assert.equal(orderPackagesMoreThenZeroQtyIds.get("length"), 2);
-});
-
-test("check dispatchedQuantity computed property", function(assert) {
-  var model, store, ordersPackage1, ordersPackage2, ordersPackage3;
-  model = this.subject();
-  store = this.store();
-
-  Ember.run(function() {
-    ordersPackage1 = store.createRecord("ordersPackage", {
-      id: 1,
-      state: "dispatched",
-      quantity: 1
-    });
-    ordersPackage2 = store.createRecord("ordersPackage", {
-      id: 2,
-      state: "dispatched",
-      quantity: 2
-    });
-    ordersPackage3 = store.createRecord("ordersPackage", {
-      id: 3,
-      state: "designated",
-      quantity: 3
-    });
-    model
-      .get("ordersPackages")
-      .pushObjects([ordersPackage1, ordersPackage2, ordersPackage3]);
-  });
-
-  assert.equal(model.get("dispatchedQuantity"), 3);
 });
 
 test("check cancelledItemCount computed property", function(assert) {

--- a/tests/unit/model/orders-package-test.js
+++ b/tests/unit/model/orders-package-test.js
@@ -59,7 +59,6 @@ test("Relationships with other models", function(assert) {
 });
 
 test("Checking computed properties", function(assert) {
-  assert.expect(2);
   var orders_package = this.subject({ state: "designated", quantity: 6 });
   assert.equal(orders_package.get("isSingleQuantity"), false);
 });

--- a/tests/unit/model/orders-package-test.js
+++ b/tests/unit/model/orders-package-test.js
@@ -1,20 +1,35 @@
-import { test, moduleForModel } from 'ember-qunit';
-import Ember from 'ember';
+import { test, moduleForModel } from "ember-qunit";
+import Ember from "ember";
 
-moduleForModel('orders_package', 'OrdersPackage Model', {
-  needs: ['model:order-transport', 'model:gc_organisation', 'model:item', 'model:image', 'model:donor_condition', 'model:user', 'model:designation', 'model:code', 'model:location', 'model:contact', 'model:organisation', 'model:local-order', 'service:utilityMethods', 'service:i18n']
+moduleForModel("orders_package", "OrdersPackage Model", {
+  needs: [
+    "model:order-transport",
+    "model:gc_organisation",
+    "model:item",
+    "model:image",
+    "model:donor_condition",
+    "model:user",
+    "model:designation",
+    "model:code",
+    "model:location",
+    "model:contact",
+    "model:organisation",
+    "model:local-order",
+    "service:utilityMethods",
+    "service:i18n"
+  ]
 });
 
-test('check attributes', function(assert){
+test("check attributes", function(assert) {
   assert.expect(7);
   var model = this.subject();
-  var packageId = Object.keys(model.toJSON()).indexOf('packageId') > -1;
-  var orderId = Object.keys(model.toJSON()).indexOf('orderId') > -1;
-  var itemId = Object.keys(model.toJSON()).indexOf('itemId') > -1;
-  var designationId = Object.keys(model.toJSON()).indexOf('designationId') > -1;
-  var quantity = Object.keys(model.toJSON()).indexOf('quantity') > -1;
-  var sentOn = Object.keys(model.toJSON()).indexOf('sentOn') > -1;
-  var state = Object.keys(model.toJSON()).indexOf('state') > -1;
+  var packageId = Object.keys(model.toJSON()).indexOf("packageId") > -1;
+  var orderId = Object.keys(model.toJSON()).indexOf("orderId") > -1;
+  var itemId = Object.keys(model.toJSON()).indexOf("itemId") > -1;
+  var designationId = Object.keys(model.toJSON()).indexOf("designationId") > -1;
+  var quantity = Object.keys(model.toJSON()).indexOf("quantity") > -1;
+  var sentOn = Object.keys(model.toJSON()).indexOf("sentOn") > -1;
+  var state = Object.keys(model.toJSON()).indexOf("state") > -1;
 
   assert.ok(packageId);
   assert.ok(orderId);
@@ -25,66 +40,75 @@ test('check attributes', function(assert){
   assert.ok(state);
 });
 
-test('Relationships with other models', function(assert) {
+test("Relationships with other models", function(assert) {
   assert.expect(4);
-  var OrdersPackage = this.store().modelFor('orders_package');
-  var relationshipWithItem = Ember.get(OrdersPackage, 'relationshipsByName').get('item');
-  var relationshipWithDesignation = Ember.get(OrdersPackage, 'relationshipsByName').get('designation');
+  var OrdersPackage = this.store().modelFor("orders_package");
+  var relationshipWithItem = Ember.get(
+    OrdersPackage,
+    "relationshipsByName"
+  ).get("item");
+  var relationshipWithDesignation = Ember.get(
+    OrdersPackage,
+    "relationshipsByName"
+  ).get("designation");
 
-  assert.equal(relationshipWithItem.key, 'item');
-  assert.equal(relationshipWithItem.kind, 'belongsTo');
-  assert.equal(relationshipWithDesignation.key, 'designation');
-  assert.equal(relationshipWithDesignation.kind, 'belongsTo');
+  assert.equal(relationshipWithItem.key, "item");
+  assert.equal(relationshipWithItem.kind, "belongsTo");
+  assert.equal(relationshipWithDesignation.key, "designation");
+  assert.equal(relationshipWithDesignation.kind, "belongsTo");
 });
 
-test('Checking computed properties', function(assert) {
+test("Checking computed properties", function(assert) {
   assert.expect(2);
   var orders_package = this.subject({ state: "designated", quantity: 6 });
-  assert.equal(orders_package.get('availableQty'), 6);
-  assert.equal(orders_package.get('isSingleQuantity'), false);
+  assert.equal(orders_package.get("isSingleQuantity"), false);
 });
 
-test('OrdersPackage is a valid ember-data Model', function(assert) {
+test("OrdersPackage is a valid ember-data Model", function(assert) {
   assert.expect(1);
 
-  var store  = this.store();
+  var store = this.store();
   var record = null;
 
   Ember.run(function() {
-    store.createRecord('orders_package', {id: 1, state: 'designated', quantity: 5});
-    record = store.peekRecord('orders_package', 1);
+    store.createRecord("orders_package", {
+      id: 1,
+      state: "designated",
+      quantity: 5
+    });
+    record = store.peekRecord("orders_package", 1);
   });
 
-  assert.equal(record.get('state'), 'designated');
+  assert.equal(record.get("state"), "designated");
 });
 
-test('check orderCode computed property', function(assert){
+test("check orderCode computed property", function(assert) {
   var model, store, designation, code;
   model = this.subject();
   store = this.store();
 
-  Ember.run(function(){
-    code = store.createRecord('code', {
-      id                      : 1,
-      name                    : 'codename',
-      code                    : "BBS",
-      otherChildPackages      : "FXX",
-      defaultChildPackages    : "BBS",
-      otherTerms              : "Cot",
-      visibleInSelects        : true
+  Ember.run(function() {
+    code = store.createRecord("code", {
+      id: 1,
+      name: "codename",
+      code: "BBS",
+      otherChildPackages: "FXX",
+      defaultChildPackages: "BBS",
+      otherTerms: "Cot",
+      visibleInSelects: true
     });
 
-    designation = store.createRecord('designation',{
-      id                :1,
-      code              :code,
-      detailType        :'StockitLocalOrder',
-      status            :'Active',
-      createdAt         :'12/07/2016',
-      updatedAt         :'12/07/2016'
+    designation = store.createRecord("designation", {
+      id: 1,
+      code: code,
+      detailType: "StockitLocalOrder",
+      status: "Active",
+      createdAt: "12/07/2016",
+      updatedAt: "12/07/2016"
     });
 
-    model.set('designation', designation);
+    model.set("designation", designation);
   });
 
-  assert.equal(model.get('orderCode'), code);
+  assert.equal(model.get("orderCode"), code);
 });

--- a/tests/unit/model/set_item-test.js
+++ b/tests/unit/model/set_item-test.js
@@ -1,246 +1,345 @@
-import { test, moduleForModel } from 'ember-qunit';
-import Ember from 'ember';
+import { test, moduleForModel } from "ember-qunit";
+import Ember from "ember";
 
-moduleForModel('set_item', 'SetItem model',{
-  needs: ['model:order-transport', 'model:code', 'model:gc_organisation', 'model:item', 'model:designation', 'model:location', 'model:code', 'model:donor_condition', 'model:packages_location', 'model:orders_package', 'model:image', 'model:contact', 'model:organisation', 'model:local-order', 'service:utilityMethods', 'service:i18n']
+moduleForModel("set_item", "SetItem model", {
+  needs: [
+    "model:order-transport",
+    "model:code",
+    "model:gc_organisation",
+    "model:item",
+    "model:designation",
+    "model:location",
+    "model:code",
+    "model:donor_condition",
+    "model:packages_location",
+    "model:orders_package",
+    "model:image",
+    "model:contact",
+    "model:organisation",
+    "model:local-order",
+    "service:utilityMethods",
+    "service:i18n"
+  ]
 });
 
-test('check attributes', function(assert){
+test("check attributes", function(assert) {
   assert.expect(1);
   var model = this.subject();
-  var description = Object.keys(model.toJSON()).indexOf('description') > -1;
+  var description = Object.keys(model.toJSON()).indexOf("description") > -1;
 
   assert.ok(description);
 });
 
-test('Relationships with other models', function(assert) {
+test("Relationships with other models", function(assert) {
   assert.expect(4);
-  var SetItem = this.store().modelFor('set_item');
-  var relationshipWithCode = Ember.get(SetItem, 'relationshipsByName').get('code');
-  var relationshipWithItem = Ember.get(SetItem, 'relationshipsByName').get('items');
+  var SetItem = this.store().modelFor("set_item");
+  var relationshipWithCode = Ember.get(SetItem, "relationshipsByName").get(
+    "code"
+  );
+  var relationshipWithItem = Ember.get(SetItem, "relationshipsByName").get(
+    "items"
+  );
 
-  assert.equal(relationshipWithCode.key, 'code');
-  assert.equal(relationshipWithCode.kind, 'belongsTo');
-  assert.equal(relationshipWithItem.key, 'items');
-  assert.equal(relationshipWithItem.kind, 'hasMany');
+  assert.equal(relationshipWithCode.key, "code");
+  assert.equal(relationshipWithCode.kind, "belongsTo");
+  assert.equal(relationshipWithItem.key, "items");
+  assert.equal(relationshipWithItem.kind, "hasMany");
 });
 
-
-test('check multiQuantitySet computed property', function(assert){
+test("check multiQuantitySet computed property", function(assert) {
   var model, store, item1, item2, item3;
   model = this.subject();
   store = this.store();
 
-  Ember.run(function(){
-    item1 = store.createRecord('item', { id: 1, quantity: 2 });
-    item2 = store.createRecord('item', { id: 2, quantity: 3 });
-    item3 = store.createRecord('item', { id: 3, quantity: 1 });
+  Ember.run(function() {
+    item1 = store.createRecord("item", { id: 1, quantity: 2 });
+    item2 = store.createRecord("item", { id: 2, quantity: 3 });
+    item3 = store.createRecord("item", { id: 3, quantity: 1 });
 
-    model.get('items').pushObjects([item1, item2, item3]);
+    model.get("items").pushObjects([item1, item2, item3]);
   });
 
-  assert.equal(model.get('multiQuantitySet'), true);
+  assert.equal(model.get("multiQuantitySet"), true);
 });
 
-test('check allDesignated, designatedItems computed properties', function(assert){
+test("check allDesignated, designatedItems computed properties", function(assert) {
   assert.expect(2);
   var model, store, item1, item2, item3, designation;
   model = this.subject();
   store = this.store();
 
-  Ember.run(function(){
-    designation = store.createRecord('designation', {
-                id:               5,
-                detailType:       'StockitLocalOrder',
-                status:           'Active',
-                createdAt:        '12/07/2016',
-                updatedAt:        '12/07/2016'
-              });
-    item1 = store.createRecord('item', { id: 1, designation: designation });
-    item2 = store.createRecord('item', { id: 2, designation: designation });
-    item3 = store.createRecord('item', { id: 3, designation: designation });
+  Ember.run(function() {
+    designation = store.createRecord("designation", {
+      id: 5,
+      detailType: "StockitLocalOrder",
+      status: "Active",
+      createdAt: "12/07/2016",
+      updatedAt: "12/07/2016"
+    });
+    item1 = store.createRecord("item", { id: 1, designation: designation });
+    item2 = store.createRecord("item", { id: 2, designation: designation });
+    item3 = store.createRecord("item", { id: 3, designation: designation });
 
-    model.get('items').pushObjects([item1, item2, item3]);
+    model.get("items").pushObjects([item1, item2, item3]);
   });
 
-  assert.equal(model.get('allDesignated'), true);
-  assert.equal(Ember.compare(model.get('designatedItems').getEach('id'),["1", "2", "3"]), 0);
+  assert.equal(model.get("allDesignated"), true);
+  assert.equal(
+    Ember.compare(model.get("designatedItems").getEach("id"), ["1", "2", "3"]),
+    0
+  );
 });
 
-test('check sortedItems computed property', function(assert){
+test("check sortedItems computed property", function(assert) {
   var model, store, item1, item2, item3;
   model = this.subject();
   store = this.store();
 
-  Ember.run(function(){
-    item1 = store.createRecord('item', { id: 1, quantity: 1 });
-    item2 = store.createRecord('item', { id: 2, quantity: 1 });
-    item3 = store.createRecord('item', { id: 3, quantity: 1 });
-    model.get('items').pushObjects([item1, item2, item3]);
+  Ember.run(function() {
+    item1 = store.createRecord("item", { id: 1, quantity: 1 });
+    item2 = store.createRecord("item", { id: 2, quantity: 1 });
+    item3 = store.createRecord("item", { id: 3, quantity: 1 });
+    model.get("items").pushObjects([item1, item2, item3]);
   });
 
-  assert.equal(Ember.compare(model.get('sortedItems').getEach('id'), ["1", "2", "3"]), 0);
+  assert.equal(
+    Ember.compare(model.get("sortedItems").getEach("id"), ["1", "2", "3"]),
+    0
+  );
 });
 
-test('check allDispatched computed property', function(assert){
+test("check allDispatched computed property", function(assert) {
   var model, store, item1, item2, item3;
   model = this.subject();
   store = this.store();
 
-  Ember.run(function(){
-    item1 = store.createRecord('item', { id: 1, isDispatched: true });
-    item2 = store.createRecord('item', { id: 2, isDispatched: true });
-    item3 = store.createRecord('item', { id: 3, isDispatched: true });
-    model.get('items').pushObjects([item1, item2, item3]);
+  Ember.run(function() {
+    item1 = store.createRecord("item", { id: 1, isDispatched: true });
+    item2 = store.createRecord("item", { id: 2, isDispatched: true });
+    item3 = store.createRecord("item", { id: 3, isDispatched: true });
+    model.get("items").pushObjects([item1, item2, item3]);
   });
 
-  assert.equal(model.get('allDispatched'), true);
+  assert.equal(model.get("allDispatched"), true);
 });
 
-test('check hasZeroQty computed property', function(assert){
-  var model, store, item;
-  model = this.subject();
-  store = this.store();
-
-  Ember.run(function(){
-    item = store.createRecord('item', { id: 1, quantity: 0 });
-    model.get('items').pushObject(item);
-  });
-
-  assert.equal(model.get('hasZeroQty'), false);
-});
-
-test('check hasSingleDesignation computed property', function(assert){
+test("check hasSingleDesignation computed property", function(assert) {
   var model, store, ordersPackage, item;
   model = this.subject();
   store = this.store();
 
-  Ember.run(function(){
-    ordersPackage = store.createRecord('orders_package', {id: 1, state: 'designated'});
-    item = store.createRecord('item', { id: 1, quantity: 0 });
-    item.get('ordersPackages').pushObject(ordersPackage);
-    model.get('items').pushObject(item);
+  Ember.run(function() {
+    ordersPackage = store.createRecord("orders_package", {
+      id: 1,
+      state: "designated"
+    });
+    item = store.createRecord("item", { id: 1, quantity: 0 });
+    item.get("ordersPackages").pushObject(ordersPackage);
+    model.get("items").pushObject(item);
   });
 
-  assert.equal(model.get('hasSingleDesignation'), true);
+  assert.equal(model.get("hasSingleDesignation"), true);
 });
 
-test('canBeMoved: Checks items are not assigned to box or pallet and can be moved', function(assert){
+test("canBeMoved: Checks items are not assigned to box or pallet and can be moved", function(assert) {
   var model, item, store;
 
   model = this.subject();
   store = this.store();
 
-  Ember.run(function(){
-    item = store.createRecord('item', { id: 1, quantity: 1 });
-    model.get('items').pushObjects([item]);
+  Ember.run(function() {
+    item = store.createRecord("item", { id: 1, quantity: 1 });
+    model.get("items").pushObjects([item]);
   });
 
-  assert.equal(model.get('canBeMoved'), true);
+  assert.equal(model.get("canBeMoved"), true);
 });
 
-test('hasSingleDesignation: Check item has single designation or not', function(assert){
+test("hasSingleDesignation: Check item has single designation or not", function(assert) {
   var item, model, store, ordersPackage;
 
   store = this.store();
   model = this.subject();
 
-  Ember.run(function(){
-    item = store.createRecord('item', { id: 1, quantity: 1 });
-    ordersPackage = store.createRecord('ordersPackage', { id: 1, quantity: 1, item: item, state: 'dispatched' });
-    model.get('items').pushObjects([item]);
+  Ember.run(function() {
+    item = store.createRecord("item", { id: 1, quantity: 1 });
+    ordersPackage = store.createRecord("ordersPackage", {
+      id: 1,
+      quantity: 1,
+      item: item,
+      state: "dispatched"
+    });
+    model.get("items").pushObjects([item]);
   });
 
-  assert.equal(model.get('hasSingleDesignation'), false);
+  assert.equal(model.get("hasSingleDesignation"), false);
 });
 
-test('setItemOrdersPackages: it returns designated and dispatched ordersPackages', function(assert){
+test("setItemOrdersPackages: it returns designated and dispatched ordersPackages", function(assert) {
   var item, model, store, ordersPackage;
 
   store = this.store();
   model = this.subject();
 
-  Ember.run(function(){
-    item = store.createRecord('item', { id: 1, quantity: 1 });
-    ordersPackage = store.createRecord('ordersPackage', { id: 1, quantity: 1, item: item, state: 'dispatched' });
-    model.get('items').pushObjects([item]);
+  Ember.run(function() {
+    item = store.createRecord("item", { id: 1, quantity: 1 });
+    ordersPackage = store.createRecord("ordersPackage", {
+      id: 1,
+      quantity: 1,
+      item: item,
+      state: "dispatched"
+    });
+    model.get("items").pushObjects([item]);
   });
 
-  assert.equal(model.get('setItemOrdersPackages'), 1);
+  assert.equal(model.get("setItemOrdersPackages"), 1);
 });
 
-test('check designatedAndDispatchedOrdersPackages computed property', function(assert){
+test("check designatedAndDispatchedOrdersPackages computed property", function(assert) {
   var setItem, store, item, ordersPackage1, ordersPackage2, ordersPackage3;
   store = this.store();
 
-  Ember.run(function(){
-    setItem = store.createRecord('set_item', {id: 1, description: 'setItem1 description'});
-    item = store.createRecord('item', { id: 1, quantity: 1 });
-    ordersPackage1 = store.createRecord('orders_package', {id: 1, state: 'dispatched'});
-    ordersPackage2 = store.createRecord('orders_package', {id: 2, state: 'designated'});
-    ordersPackage3 = store.createRecord('orders_package', {id: 3, state: 'cancelled'});
+  Ember.run(function() {
+    setItem = store.createRecord("set_item", {
+      id: 1,
+      description: "setItem1 description"
+    });
+    item = store.createRecord("item", { id: 1, quantity: 1 });
+    ordersPackage1 = store.createRecord("orders_package", {
+      id: 1,
+      state: "dispatched"
+    });
+    ordersPackage2 = store.createRecord("orders_package", {
+      id: 2,
+      state: "designated"
+    });
+    ordersPackage3 = store.createRecord("orders_package", {
+      id: 3,
+      state: "cancelled"
+    });
 
-    item.get('ordersPackages').pushObjects([ordersPackage1, ordersPackage2, ordersPackage3]);
-    setItem.get('items').pushObject(item);
+    item
+      .get("ordersPackages")
+      .pushObjects([ordersPackage1, ordersPackage2, ordersPackage3]);
+    setItem.get("items").pushObject(item);
   });
 
-  assert.equal(setItem.get('designatedAndDispatchedOrdersPackages').getEach("id"), 0);
+  assert.equal(
+    setItem.get("designatedAndDispatchedOrdersPackages").getEach("id"),
+    0
+  );
 });
 
-test('check setItemOrdersPackages computed property', function(assert){
+test("check setItemOrdersPackages computed property", function(assert) {
   var model, store, item, ordersPackage1, ordersPackage2, ordersPackage3;
   model = this.subject();
   store = this.store();
 
-  Ember.run(function(){
-    item = store.createRecord('item', { id: 1, quantity: 1 });
-    ordersPackage1 = store.createRecord('orders_package', {id: 1, state: 'dispatched', quantity: 2});
-    ordersPackage2 = store.createRecord('orders_package', {id: 2, state: 'designated', quantity: 3});
-    ordersPackage3 = store.createRecord('orders_package', {id: 3, state: 'cancelled', quantity: 2});
+  Ember.run(function() {
+    item = store.createRecord("item", { id: 1, quantity: 1 });
+    ordersPackage1 = store.createRecord("orders_package", {
+      id: 1,
+      state: "dispatched",
+      quantity: 2
+    });
+    ordersPackage2 = store.createRecord("orders_package", {
+      id: 2,
+      state: "designated",
+      quantity: 3
+    });
+    ordersPackage3 = store.createRecord("orders_package", {
+      id: 3,
+      state: "cancelled",
+      quantity: 2
+    });
 
-    item.get('ordersPackages').pushObjects([ordersPackage1, ordersPackage2, ordersPackage3]);
-    model.get('items').pushObject(item);
+    item
+      .get("ordersPackages")
+      .pushObjects([ordersPackage1, ordersPackage2, ordersPackage3]);
+    model.get("items").pushObject(item);
   });
 
-  assert.equal(model.get('setItemOrdersPackages'), 2);
+  assert.equal(model.get("setItemOrdersPackages"), 2);
 });
 
-test('check hasSameSingleDesignation computed property', function(assert){
-  var model, store, item1, item2, ordersPackage1, ordersPackage2, ordersPackage3, ordersPackage4, ordersPackage5, ordersPackage6;
+test("check hasSameSingleDesignation computed property", function(assert) {
+  var model,
+    store,
+    item1,
+    item2,
+    ordersPackage1,
+    ordersPackage2,
+    ordersPackage3,
+    ordersPackage4,
+    ordersPackage5,
+    ordersPackage6;
   model = this.subject();
   store = this.store();
 
-  Ember.run(function(){
-    item1 = store.createRecord('item', { id: 1, quantity: 1 });
-    item2 = store.createRecord('item', { id: 2, quantity: 1 });
-    ordersPackage1 = store.createRecord('orders_package', {id: 1, state: 'dispatched', quantity: 2});
-    ordersPackage2 = store.createRecord('orders_package', {id: 2, state: 'designated', quantity: 3});
-    ordersPackage3 = store.createRecord('orders_package', {id: 3, state: 'cancelled', quantity: 2});
-    ordersPackage4 = store.createRecord('orders_package', {id: 4, state: 'dispatched', quantity: 2});
-    ordersPackage5 = store.createRecord('orders_package', {id: 5, state: 'designated', quantity: 3});
-    ordersPackage6 = store.createRecord('orders_package', {id: 6, state: 'cancelled', quantity: 2});
+  Ember.run(function() {
+    item1 = store.createRecord("item", { id: 1, quantity: 1 });
+    item2 = store.createRecord("item", { id: 2, quantity: 1 });
+    ordersPackage1 = store.createRecord("orders_package", {
+      id: 1,
+      state: "dispatched",
+      quantity: 2
+    });
+    ordersPackage2 = store.createRecord("orders_package", {
+      id: 2,
+      state: "designated",
+      quantity: 3
+    });
+    ordersPackage3 = store.createRecord("orders_package", {
+      id: 3,
+      state: "cancelled",
+      quantity: 2
+    });
+    ordersPackage4 = store.createRecord("orders_package", {
+      id: 4,
+      state: "dispatched",
+      quantity: 2
+    });
+    ordersPackage5 = store.createRecord("orders_package", {
+      id: 5,
+      state: "designated",
+      quantity: 3
+    });
+    ordersPackage6 = store.createRecord("orders_package", {
+      id: 6,
+      state: "cancelled",
+      quantity: 2
+    });
 
-    item1.get('ordersPackages').pushObjects([ordersPackage1, ordersPackage2, ordersPackage3]);
-    item2.get('ordersPackages').pushObjects([ordersPackage4, ordersPackage5, ordersPackage6]);
-    model.get('items').pushObjects([item1, item2]);
+    item1
+      .get("ordersPackages")
+      .pushObjects([ordersPackage1, ordersPackage2, ordersPackage3]);
+    item2
+      .get("ordersPackages")
+      .pushObjects([ordersPackage4, ordersPackage5, ordersPackage6]);
+    model.get("items").pushObjects([item1, item2]);
   });
 
-  assert.equal(model.get('hasSameSingleDesignation'), true);
+  assert.equal(model.get("hasSameSingleDesignation"), true);
 });
 
-test('designations: returns designated ordersPackages', function(assert){
+test("designations: returns designated ordersPackages", function(assert) {
   var item, model, store, ordersPackage, designation;
 
   store = this.store();
   model = this.subject();
 
-  Ember.run(function(){
-    item = store.createRecord('item', { id: 1, quantity: 1 });
-    designation = store.createRecord('designation', { id: 1, code: 'L1'});
-    ordersPackage = store.createRecord('ordersPackage', { id: 1, quantity: 1, item: item, state: 'dispatched',
-      designation: designation });
-    model.get('designatedSetItemOrderPackages').pushObject([ordersPackage]);
+  Ember.run(function() {
+    item = store.createRecord("item", { id: 1, quantity: 1 });
+    designation = store.createRecord("designation", { id: 1, code: "L1" });
+    ordersPackage = store.createRecord("ordersPackage", {
+      id: 1,
+      quantity: 1,
+      item: item,
+      state: "dispatched",
+      designation: designation
+    });
+    model.get("designatedSetItemOrderPackages").pushObject([ordersPackage]);
   });
 
-  assert.equal(model.get('designations.length'), 1);
+  assert.equal(model.get("designations.length"), 1);
 });


### PR DESCRIPTION
This PR is dependant on https://github.com/crossroads/api.goodcity/pull/926

## Changes

- Addition of the following fields to the `item` model (which is actually a `package`)
    * `availableQuantity`
    * `onHandQuantity`
    * `dispatchedQuantity`
    * `designatedQuantity`
- The `quantity` field is now an alias to `availableQuantity` (as a temporary safeguard)
- Computed quantities `totalDesignatedQty` and `totalDispatchedQty` substituted with the actual fields
- Changed all the reads of old quantities I found to the new properties