### PR TITLE
GCW_3078 created_at date shown as the "Submitted date" fix

### DIFF
--- a/app/templates/orders/_order_status_bar.hbs
+++ b/app/templates/orders/_order_status_bar.hbs
@@ -4,7 +4,7 @@
       <div class="small-12 columns status">
         <div class="time-details">
           {{#if (is-equal model.capitalizedState "Submitted")}}
-            {{t "order.submitted"}}, {{display-datetime model.createdAt format="DD MMM 'YY"}}
+            {{t "order.submitted"}}, {{display-datetime model.submittedAt format="DD MMM 'YY"}}
           {{else if (is-equal model.capitalizedState "Processing")}}
             {{model.capitalizedState}}, {{display-datetime model.processedAt format="DD MMM 'YY"}}
           {{else if (is-equal model.capitalizedState "Awaiting_dispatch")}}
@@ -60,7 +60,7 @@
   {{else}}
     <div class="small-12 columns order-status">
       <div class="time-details">
-        {{t "order_details.submitted"}} {{display-datetime model.createdAt format="DD MMM 'YY"}}
+        {{t "order_details.submitted"}} {{display-datetime model.submittedAt format="DD MMM 'YY"}}
       </div>
       <div class="state">
         {{model.status}}


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3078

### What does this PR do?

BUG: on stock orders details page, submitted at date was picking up the wrong value. i.e. createdAt.

Fixed that issue