### PR TITLE
FIX=> wrong offer received_at duration on offers search overlay

### DIFF
--- a/app/models/offer.js
+++ b/app/models/offer.js
@@ -9,5 +9,6 @@ export default DS.Model.extend({
   companyId: attr("number"),
   createdById: attr("string"),
   company: belongsTo("company", { async: false }),
-  createdBy: belongsTo("user", { async: false })
+  createdBy: belongsTo("user", { async: false }),
+  receivedAt: attr("date")
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stock",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "private": true,
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Hi Team,
This PR fixes wrong `received_at` duration on Offer search overlay.
Please review this PR.

