### PR TITLE
GCW-3085-Order show action performance improvement

### DIFF
--- a/app/adapters/designation.js
+++ b/app/adapters/designation.js
@@ -1,10 +1,23 @@
-import ApplicationAdapter from './application';
+import ApplicationAdapter from "./application";
+import _ from "lodash";
 
 export default ApplicationAdapter.extend({
   // Intercept the update method of designations, to send the data with the 'order' name instead
   updateRecord(store, type, snapshot) {
     let data = this.serialize(snapshot, { includeId: true });
-    const url = this.buildURL('order', snapshot.id, snapshot, 'updateRecord');
-    return this.ajax(url, 'PUT', { data: { 'order' : data } });
+    const url = this.buildURL("order", snapshot.id, snapshot, "updateRecord");
+    return this.ajax(url, "PUT", { data: { order: data } });
+  },
+
+  //For contstructing /show endpoint with queryParams for designations
+  urlForFindRecord(id, modelName, snapshot) {
+    const params = {
+      include_packages: false,
+      include_order: true,
+      include_orders_packages: false
+    };
+    let baseUrl = this.buildURL(modelName, id, snapshot);
+    const paramStr = _.map(params, (value, key) => `${key}=${value}`).join("&");
+    return `${baseUrl}?${paramStr}`;
   }
 });

--- a/app/controllers/items/index.js
+++ b/app/controllers/items/index.js
@@ -78,11 +78,7 @@ export default Ember.Controller.extend(SearchMixin, {
         )
       );
 
-      return this.get("store")
-        .query("item", params)
-        .then(results => {
-          return results;
-        });
+      return this.get("store").query("item", params);
     },
 
     clearSearch() {

--- a/app/models/item.js
+++ b/app/models/item.js
@@ -42,7 +42,7 @@ export default cloudinaryUrl.extend({
   }),
   designationId: attr("string"),
   designation: belongsTo("designation", {
-    async: true
+    async: false
   }),
   location: belongsTo("location", {
     async: false
@@ -74,7 +74,7 @@ export default cloudinaryUrl.extend({
   onHandQuantity: attr("number"),
 
   ordersPackages: hasMany("ordersPackages", {
-    async: true
+    async: false
   }),
   ordersPackages: hasMany("ordersPackages", { async: true }),
   offersPackages: hasMany("offersPackages", { async: false }),

--- a/app/routes/orders/detail.js
+++ b/app/routes/orders/detail.js
@@ -5,10 +5,7 @@ export default AuthorizeRoute.extend({
   designationService: Ember.inject.service(),
   currentRouteName: null,
 
-  model(params) {
-    const id = params.order_id;
-    return this.get("designationService")
-      .getOrder(id)
-      .then(() => this.loadIfAbsent("designation", id));
+  model({ order_id }) {
+    return this.loadIfAbsent("designation", order_id);
   }
 });

--- a/app/services/designation-service.js
+++ b/app/services/designation-service.js
@@ -157,17 +157,6 @@ export default ApiBaseService.extend(NavigationAwareness, {
     return deferred.promise;
   },
 
-  getOrder(orderId) {
-    const params = {
-      include_packages: false,
-      include_order: true,
-      include_orders_packages: false
-    };
-    return this.GET(`/designations/${orderId}`, params).then(order => {
-      this.get("store").pushPayload(order);
-    });
-  },
-
   onNavigation() {
     this.getWithDefault("onOrderSelected", _.noop)(null);
   }


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3085

### What does this PR do?
I've removed some repeated `GET` request of order show action. Also made some changes in models which ultimately remove `order` async `GET` request on `items` search page (which is the main source of error on rollbar).

### Impacted Areas
There are multiple area where we need to inspect performance improvement.
- Order details page (going into orders)
- Items search page: on doing infinite scrolling on Items search page there isn't any `GET` request  for Orders.

Please review this PR.