### PR TITLE
Remove package fetch on live updates

### DIFF
--- a/app/services/subscription.js
+++ b/app/services/subscription.js
@@ -65,7 +65,7 @@ export default Ember.Service.extend(Ember.Evented, {
       operations: ["update", "delete"]
     },
     item: {
-      strategy: UPDATE_STRATEGY.RELOAD
+      strategy: UPDATE_STRATEGY.MERGE
     },
     message: {
       strategy: [UPDATE_STRATEGY.MERGE, UPDATE_STRATEGY.SAVE_SENDER]


### PR DESCRIPTION
As titled. We merge the data without doing a fresh fetch.

Possible regressions: dependencies updated but not reflected inn the app