### PR TITLE
show request tab on order only for goodcity orders

### DIFF
--- a/app/templates/orders/_items_list_tabs.hbs
+++ b/app/templates/orders/_items_list_tabs.hbs
@@ -1,21 +1,32 @@
 <section class="main-section order_tabs order_item_list_tabs">
   <div class="row">
-    <div class="small-12 columns tab_row">
-      <dl class="tabs" data-tab>
-        <dd class="small-6 medium-6 columns text-center
-        {{if (is-equal tabName 'active_items') 'active'}}">
-          {{#link-to 'orders.active_items' model.id replace=true}}
-          <div>{{t 'items_list_tabs.active'}} ({{ordersPkgLength}})</div>
-          {{/link-to}}
-        </dd>
+    {{#if model.isGoodCityOrder}}
+      <div class="small-12 columns tab_row">
+        <dl class="tabs" data-tab>
+          <dd class="small-6 medium-6 columns text-center
+          {{if (is-equal tabName 'active_items') 'active'}}">
+            {{#link-to 'orders.active_items' model.id replace=true}}
+              <div>{{t 'items_list_tabs.active'}} ({{ordersPkgLength}})</div>
+            {{/link-to}}
+          </dd>
 
-        <dd class="small-6 medium-6 columns text-center
-        {{if (is-equal tabName 'requested_items') 'active'}}">
-          {{#link-to 'orders.requested_items' model.id replace=true}}
-          <div>{{t 'items_list_tabs.requests'}} ({{model.goodcityRequests.length}})</div>
-          {{/link-to}}
-        </dd>
-      </dl>
-    </div>
+          <dd class="small-6 medium-6 columns text-center {{if (is-equal tabName 'requested_items') 'active'}}">
+            {{#link-to 'orders.requested_items' model.id replace=true}}
+              <div>{{t 'items_list_tabs.requests'}} ({{model.goodcityRequests.length}})</div>
+            {{/link-to}}
+          </dd>
+        </dl>
+      </div>
+    {{else}}
+      <div class="small-12 columns tab_row">
+        <dl class="tabs" data-tab>
+          <dd class="small-12 medium-12 columns text-center {{if (is-equal tabName 'active_items') 'active'}}">
+            {{#link-to 'orders.active_items' model.id replace=true}}
+              <div>{{t 'items_list_tabs.active'}} ({{ordersPkgLength}})</div>
+            {{/link-to}}
+          </dd>
+        </dl>
+      </div>
+    {{/if}}
   </div>
 </section>


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2945

### What does this PR do?

As per discussion on the ticket, the request tab should be only visible on GoodCityOrders.

Please review.

Thanks.