### PR TITLE
GCW-3091-back button issue on orders Item search

### DIFF
--- a/app/controllers/orders/items.js
+++ b/app/controllers/orders/items.js
@@ -4,7 +4,6 @@ import _ from "lodash";
 import SearchMixin from "stock/mixins/search_resource";
 
 export default Ember.Controller.extend(SearchMixin, {
-  // queryParams: ["searchInput"],
   hideDetailsLink: true,
   settings: Ember.inject.service(),
 
@@ -21,18 +20,6 @@ export default Ember.Controller.extend(SearchMixin, {
       restrictMultiQuantity: this.get("settings.onlyDesignateSingletons")
     };
   },
-
-  scannedItemWatcher: Ember.observer("searchInput", function() {
-    const searchInput = this.get("searchInput") || "";
-    const sanitizedString = this.sanitizeString(searchInput);
-    if (sanitizedString) {
-      this.set("searchText", sanitizedString);
-    }
-  }),
-
-  scannedTextWatcher: Ember.observer("searchText", function() {
-    this.set("searchInput", this.get("searchText"));
-  }),
 
   triggerDisplayDesignateOverlay() {
     this.set("autoDisplayOverlay", true);
@@ -54,6 +41,10 @@ export default Ember.Controller.extend(SearchMixin, {
         .then(results => {
           return results;
         });
+    },
+
+    setScannedSearchText(searchedText) {
+      this.set("searchText", searchedText);
     },
 
     clearSearch() {

--- a/app/controllers/orders/items.js
+++ b/app/controllers/orders/items.js
@@ -4,7 +4,7 @@ import _ from "lodash";
 import SearchMixin from "stock/mixins/search_resource";
 
 export default Ember.Controller.extend(SearchMixin, {
-  queryParams: ["searchInput"],
+  // queryParams: ["searchInput"],
   hideDetailsLink: true,
   settings: Ember.inject.service(),
 

--- a/app/routes/orders/items.js
+++ b/app/routes/orders/items.js
@@ -1,17 +1,17 @@
 import getOrderRoute from "./get_order";
 
 export default getOrderRoute.extend({
-  queryParams: {
-    searchInput: ""
-  },
+  // queryParams: {
+  //   searchInput: ""
+  // },
 
-  setupController(controller, model) {
-    this._super(controller, model);
-    controller.set(
-      "searchText",
-      this.paramsFor("orders.items").searchInput || ""
-    );
-  },
+  // setupController(controller, model) {
+  //   this._super(controller, model);
+  //   controller.set(
+  //     "searchText",
+  //     this.paramsFor("orders.items").searchInput || ""
+  //   );
+  // },
 
   resetController(controller) {
     controller.hideResults();

--- a/app/routes/orders/items.js
+++ b/app/routes/orders/items.js
@@ -1,17 +1,16 @@
 import getOrderRoute from "./get_order";
 
 export default getOrderRoute.extend({
-  // queryParams: {
-  //   searchInput: ""
-  // },
+  queryParams: {
+    searchInput: ""
+  },
 
-  // setupController(controller, model) {
-  //   this._super(controller, model);
-  //   controller.set(
-  //     "searchText",
-  //     this.paramsFor("orders.items").searchInput || ""
-  //   );
-  // },
+  setupController(controller, model) {
+    this._super(controller, model);
+    if (this.paramsFor("orders.items").searchInput) {
+      controller.set("searchText", this.paramsFor("orders.items").searchInput);
+    }
+  },
 
   resetController(controller) {
     controller.hideResults();

--- a/app/templates/orders/active_items.hbs
+++ b/app/templates/orders/active_items.hbs
@@ -14,7 +14,7 @@
   {{#unless (is-or model.isCancelled model.isClosed)}}
     <div class="row add_item_button">
       <div class=" {{if isMobileApp 'small-9' 'small-12'}} columns">
-          {{#link-to "orders.items" model (query-params searchInput="") class="button expand"}}{{t "order_details.add_item_to_order"}}{{/link-to}}
+          {{#link-to "orders.items" model class="button expand"}}{{t "order_details.add_item_to_order"}}{{/link-to}}
       </div>
       {{#if isMobileApp}}
         <div class="small-3 columns">

--- a/app/templates/orders/items.hbs
+++ b/app/templates/orders/items.hbs
@@ -19,7 +19,7 @@
 
   {{#if isMobileApp}}
     <div class="small-2 large-1 columns scan-button">
-      {{scan-barcode-button record=model route="orders.items"}}
+      {{scan-barcode-button record=model onScanComplete=(action "setScannedSearchText")}}
     </div>
   {{/if}}
 </div>


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3091

### What does this PR do?

BUG: Removed observers for search input query params. Used "onScanComplete" callback for search Items page to avoid usage of observers.

### Impacted Areas

NOTE: 1) Orders Active Items page 2) Search items page for orders.


