### PR TITLE
GCW-2951-Fixed arrow issue in active_items page

### DIFF
--- a/app/styles/templates/components/_side_drawer.scss
+++ b/app/styles/templates/components/_side_drawer.scss
@@ -25,6 +25,10 @@
   .arrow-icon-holder {
     font-size: 2rem;
     padding-left: 1.5rem;
+
+    @media #{$small-only} {
+      padding-left: 0.5rem;
+    }
   }
 
   .content-wrapper {


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2951

### What does this PR do?

Arrow button now appear correctly in small screens 

### Screenshots

![Screen Shot 2020-04-02 at 12 07 38 PM](https://user-images.githubusercontent.com/60003954/78217948-9f264780-74da-11ea-86d7-fd5e3482f4c9.png)
![Screen Shot 2020-04-02 at 12 07 25 PM](https://user-images.githubusercontent.com/60003954/78217965-a2b9ce80-74da-11ea-99bf-108e97477707.png)
![Screen Shot 2020-04-02 at 12 06 40 PM](https://user-images.githubusercontent.com/60003954/78217976-a5b4bf00-74da-11ea-93d4-d0e969d453df.png)




