### PR TITLE
GCW-3112-Client name appears as 'undefined undefined' when a new order is created from Browse

### DIFF
--- a/app/routes/orders/client_summary.js
+++ b/app/routes/orders/client_summary.js
@@ -1,3 +1,17 @@
 import detail from "./detail";
 
-export default detail.extend({});
+export default detail.extend({
+  async model() {
+    const order = await this._super(...arguments);
+    return Ember.RSVP.hash({
+      order,
+      beneficiary: this.loadIfAbsent("beneficiary", order.get("beneficiaryId"))
+    });
+  },
+
+  setupController(controller, model) {
+    if (controller) {
+      controller.set("model", model.order);
+    }
+  }
+});

--- a/tests/acceptance/purpose-test.js
+++ b/tests/acceptance/purpose-test.js
@@ -13,7 +13,7 @@ import FactoryGuy from "ember-data-factory-guy";
 import { mockFindAll } from "ember-data-factory-guy";
 import MockUtils from "../helpers/mock-utils";
 
-var App, beneficiary;
+var App, beneficiary, location, code;
 
 module("Acceptance: Order Client summary", {
   beforeEach: function() {
@@ -27,12 +27,19 @@ module("Acceptance: Order Client summary", {
     beneficiary = FactoryGuy.make("beneficiary", {
       identity_type: FactoryGuy.make("identity_type")
     });
+    location = FactoryGuy.make("location");
+    code = FactoryGuy.make("code", { location: location });
     const designation = FactoryGuy.make("designation", {
       detailType: "GoodCity",
       code: "GC-00001",
+      beneficiaryId: beneficiary.id,
       beneficiary
     }).toJSON({ includeId: true });
 
+    MockUtils.mock({
+      url: "/api/v1/beneficiar*",
+      responseText: { beneficiary: beneficiary }
+    });
     MockUtils.mockWithRecords("designation", [designation]);
     MockUtils.mockWithRecords(
       "cancellation_reason",


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3112

### What does this PR do?

BUG:  Due to shallow loading of orders in search, beneficiary association isn't getting load. This PR adds explicit beneficiary request in client summary page.

### Impacted Areas

Orders -> Client Summary 
