### PR TITLE
GCW-3121 Show create orders for users with order permissions

### DIFF
--- a/app/models/user_profile.js
+++ b/app/models/user_profile.js
@@ -1,58 +1,71 @@
-import Ember from 'ember';
-import DS from 'ember-data';
-import Addressable from './addressable';
+import Ember from "ember";
+import DS from "ember-data";
+import Addressable from "./addressable";
 
 var attr = DS.attr;
 
 export default Addressable.extend({
-  firstName:   attr('string'),
-  lastName:    attr('string'),
-  mobile:      attr('string'),
+  firstName: attr("string"),
+  lastName: attr("string"),
+  mobile: attr("string"),
 
-  userRoles: DS.hasMany('userRoles', { async: false }),
+  userRoles: DS.hasMany("userRoles", { async: false }),
 
-  roles: Ember.computed('userRoles.[]', function(){
-    return this.get('userRoles').map(userRole => userRole.get('role'));
+  roles: Ember.computed("userRoles.[]", function() {
+    return this.get("userRoles").map(userRole => userRole.get("role"));
   }),
 
-  roleNames: Ember.computed('roles', function(){
-    if(this.get('roles.length')){
-      return this.get('roles').getEach('name');
+  roleNames: Ember.computed("roles", function() {
+    if (this.get("roles.length")) {
+      return this.get("roles").getEach("name");
     }
   }),
 
-  isReviewer: Ember.computed('roleNames', function(){
-    if(this.get("roleNames") && this.get("roleNames").length) {
-      return (this.get('roleNames').indexOf('Reviewer') >= 0);
+  isReviewer: Ember.computed("roleNames", function() {
+    if (this.get("roleNames") && this.get("roleNames").length) {
+      return this.get("roleNames").indexOf("Reviewer") >= 0;
     }
   }),
 
-  isSupervisor: Ember.computed('roleNames', function(){
-    if(this.get("roleNames") && this.get("roleNames").length) {
-      return (this.get('roleNames').indexOf('Supervisor') >= 0);
+  isSupervisor: Ember.computed("roleNames", function() {
+    if (this.get("roleNames") && this.get("roleNames").length) {
+      return this.get("roleNames").indexOf("Supervisor") >= 0;
     }
   }),
 
-  isOrderFulfilmentUser: Ember.computed('roleNames', function(){
-    if(this.get("roleNames") && this.get("roleNames").length) {
-      return (this.get('roleNames').indexOf('Order fulfilment') >= 0);
+  isOrderFulfilmentUser: Ember.computed("roleNames", function() {
+    if (this.get("roleNames") && this.get("roleNames").length) {
+      return this.get("roleNames").indexOf("Order fulfilment") >= 0;
     }
   }),
 
-  canViewDashboard: Ember.computed('isOrderFulfilmentUser', 'isSupervisor', function () {
-    return this.get('isOrderFulfilmentUser') || this.get('isSupervisor');
+  canViewDashboard: Ember.computed(
+    "isOrderFulfilmentUser",
+    "isSupervisor",
+    function() {
+      return this.get("isOrderFulfilmentUser") || this.get("isSupervisor");
+    }
+  ),
+
+  canManageAppointments: Ember.computed("roles", function() {
+    const roles = this.get("roles");
+    return roles.find(
+      r => r.get("permissionNames").indexOf("can_manage_settings") >= 0
+    );
   }),
 
-  canManageAppointments: Ember.computed('roles', function(){
-    const roles = this.get('roles');
-    return roles.find((r) => r.get('permissionNames').indexOf('can_manage_settings') >= 0);
+  canManageOrders: Ember.computed("roles", function() {
+    const roles = this.get("roles");
+    return roles.find(
+      r => r.get("permissionNames").indexOf("can_manage_orders") >= 0
+    );
   }),
 
-  mobileWithCountryCode: Ember.computed('mobile', function(){
-    return this.get('mobile') ? ("+852" + this.get('mobile')) : "";
+  mobileWithCountryCode: Ember.computed("mobile", function() {
+    return this.get("mobile") ? "+852" + this.get("mobile") : "";
   }),
 
-  fullName: Ember.computed('firstName', 'lastName', function(){
-    return (this.get('firstName') + " " + this.get('lastName'));
+  fullName: Ember.computed("firstName", "lastName", function() {
+    return this.get("firstName") + " " + this.get("lastName");
   })
 });

--- a/app/templates/app_menu_list.hbs
+++ b/app/templates/app_menu_list.hbs
@@ -36,12 +36,14 @@
           </a>
         </li>
       {{/each}}
-      {{#if (is-or session.currentUser.canManageOrders getCurrentUser.canManageOrders)}}
+      {{#if (is-or session.currentUser.canManageAppointments getCurrentUser.canManageAppointments)}}
         <li class="menu-list">
           {{#link-to 'appointments' class='appointments-link menu-list-anchor'}}
             {{fa-icon 'calendar-alt' size="lg"}}&nbsp;&nbsp;{{t 'manage_inventory'}}
           {{/link-to}}
         </li>
+      {{/if}}
+      {{#if (is-or session.currentUser.canManageOrders getCurrentUser.canManageOrders)}}
         <li class="menu-list">
           <a href="#" class="menu-list-anchor" {{action 'createOrder'}}>
             {{fa-icon 'shopping-basket' size="lg"}}&nbsp;&nbsp;{{t 'new_order'}}

--- a/app/templates/app_menu_list.hbs
+++ b/app/templates/app_menu_list.hbs
@@ -36,14 +36,14 @@
           </a>
         </li>
       {{/each}}
-      {{#if (is-or session.currentUser.canManageAppointments getCurrentUser.canManageAppointments)}}
+      {{#if getCurrentUser.canManageAppointments}}
         <li class="menu-list">
           {{#link-to 'appointments' class='appointments-link menu-list-anchor'}}
             {{fa-icon 'calendar-alt' size="lg"}}&nbsp;&nbsp;{{t 'manage_inventory'}}
           {{/link-to}}
         </li>
       {{/if}}
-      {{#if (is-or session.currentUser.canManageOrders getCurrentUser.canManageOrders)}}
+      {{#if getCurrentUser.canManageOrders}}
         <li class="menu-list">
           <a href="#" class="menu-list-anchor" {{action 'createOrder'}}>
             {{fa-icon 'shopping-basket' size="lg"}}&nbsp;&nbsp;{{t 'new_order'}}

--- a/app/templates/app_menu_list.hbs
+++ b/app/templates/app_menu_list.hbs
@@ -22,7 +22,7 @@
           {{fa-icon 'sign-out-alt' size="lg"}}&nbsp;&nbsp;{{t "logout.logout"}}
         </a>
       </li>
-      {{#if (is-or session.currentUser.isSupervisor getCurrentUser.isSupervisor)}}
+      {{#if (is-or getCurrentUser.isSupervisor)}}
         <li class="menu-list">
           {{#link-to 'search_organisation' class="menu-list-anchor"}}
             {{fa-icon 'user-cog' size="lg"}}&nbsp;&nbsp;{{t "manage_charity_users"}}

--- a/app/templates/app_menu_list.hbs
+++ b/app/templates/app_menu_list.hbs
@@ -36,7 +36,7 @@
           </a>
         </li>
       {{/each}}
-      {{#if (is-or session.currentUser.canManageAppointments getCurrentUser.canManageAppointments)}}
+      {{#if (is-or session.currentUser.canManageOrders getCurrentUser.canManageOrders)}}
         <li class="menu-list">
           {{#link-to 'appointments' class='appointments-link menu-list-anchor'}}
             {{fa-icon 'calendar-alt' size="lg"}}&nbsp;&nbsp;{{t 'manage_inventory'}}


### PR DESCRIPTION
### Ticket Link: 
https://jira.crossroads.org.hk/browse/GCW-3121

### What does this PR do?
The `Create New Order` would be shown to users who had `can_manage_settings` permissions. It needs to be shown to users who have `can_manage_orders` permissions

### Impacted Areas
Create new orders

### Linked PR's:
https://github.com/crossroads/api.goodcity/pull/976