### PR TITLE
GCW-3145 Fix expiry_date rollbar error

### DIFF
--- a/app/controllers/items/new.js
+++ b/app/controllers/items/new.js
@@ -172,9 +172,21 @@ export default GoodcityController.extend(
         ...this.get("dropDownValues"),
         ...this.get("countryValue")
       };
-      Object.keys(attributes).forEach(key => {
-        detailAttributes[_.snakeCase(key)] = attributes[key];
+
+      // https://jira.crossroads.org.hk/browse/GCW-3145
+      // A check to pass only those fields in detailAttributes, which are
+      // part of subforms
+      const display = this.get("displayFields").map(i => i.name);
+
+      Object.keys(attributes).map(key => {
+        const isSubFormAttr =
+          (key == "country_id" && display.includes("country")) ||
+          display.includes(key);
+        if (isSubFormAttr) {
+          detailAttributes[_.snakeCase(key)] = attributes[key];
+        }
       });
+
       return detailAttributes;
     },
 


### PR DESCRIPTION
### Ticket Link: 
https://jira.crossroads.org.hk/browse/GCW-3145

`expiry_date` was being passed as attribute for under `detail_attributes` and was causing this error.

This fix will only allow the params that are part of display fields to be passed under `detail_attributes`