### PR TITLE
[FIX] Package type selection overlay

### DIFF
--- a/app/controllers/items/detail.js
+++ b/app/controllers/items/detail.js
@@ -482,7 +482,8 @@ export default GoodcityController.extend(
 
         const code = await this.get("packageTypeService").userPickPackageType({
           storageType: "Package",
-          subsetPackageTypes: allowedPackageTypes
+          subsetPackageTypes: allowedPackageTypes,
+          headerText: this.get("i18n").t("items.select_set_type")
         });
 
         return this.runTask(async () => {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -781,6 +781,8 @@ export default {
         blank_notification: "Location cannot be blank."
       }
     },
+    select_set_type: "Select a type for the new set",
+    containers_label: "Boxes or pallets that contain this item",
     action_label: "Actions",
     make_set: "Make Set",
     actions: {

--- a/app/locales/zh-tw/translations.js
+++ b/app/locales/zh-tw/translations.js
@@ -757,6 +757,8 @@ export default {
         blank_notification: "Location cannot be blank."
       }
     },
+    select_set_type: "Select a type for the new set",
+    containers_label: "Boxes or pallets that contain this item",
     action_label: "Actions",
     make_set: "Make Set",
     actions: {

--- a/app/services/package-service.js
+++ b/app/services/package-service.js
@@ -182,6 +182,7 @@ export default ApiBaseService.extend(NavigationAwareness, {
       pkgType ||
       (await this.get("packageTypeService").userPickPackageType({
         storageType: "Package",
+        headerText: this.get("i18n").t("items.select_set_type"),
         subsetPackageTypes: this.get("packageTypeService").parentsOf(
           pkg.get("code")
         )

--- a/app/services/package-type-service.js
+++ b/app/services/package-type-service.js
@@ -46,10 +46,13 @@ export default Ember.Service.extend({
 
     const node = hierarchy.refs[code];
 
-    return _.flatten([
-      ...node.parents.map(({ type }) => type),
-      ...node.parents.map(({ type }) => this.parentsOf(type))
-    ]);
+    return _.uniq(
+      _.flatten([
+        packageType,
+        ...node.parents.map(({ type }) => type),
+        ...node.parents.map(({ type }) => this.parentsOf(type))
+      ])
+    );
   },
 
   // ----- Data -----

--- a/app/templates/_global_components.hbs
+++ b/app/templates/_global_components.hbs
@@ -21,6 +21,7 @@
     open=s.openPackageTypeSearch
     storageType=s.packageTypeSearchOptions.storageType
     subsetPackageTypes=s.packageTypeSearchOptions.subsetPackageTypes
+    headerText=s.packageTypeSearchOptions.headerText
     onSelect=s.onPackageTypeSelected
   }}
 {{/let-alias}}

--- a/app/templates/components/goodcity/code-search-overlay.hbs
+++ b/app/templates/components/goodcity/code-search-overlay.hbs
@@ -17,6 +17,11 @@
         </div>
       </div>
       <section class="main-section orders_search_result search_result">
+        {{#if headerText}}
+          <div class="row header-text">
+            <h2>{{ headerText }}</h2>
+          </div>
+        {{/if}}
         <div class="row search">
           <div class="small-12 columns">
             <ul class="list list-activity list-offer-items codes_results">

--- a/app/templates/items/detail/tabs/location.hbs
+++ b/app/templates/items/detail/tabs/location.hbs
@@ -52,7 +52,7 @@
   <div>
     {{!-- BOXES --}}
     <div class="row header-row bottom">
-      Boxes or pallets that contain this item
+      {{t 'items.containers_label'}}
     </div>
     <div class="row content-row box-list">
       {{#reactive-view model=model}}


### PR DESCRIPTION
Issues found while testing:

* Creating a set prompts to select a package type, but it only shows the Parent types, without the type itself
* Missing text to the overlay to indicate what they are picking
* Missing translation