### PR TITLE
GCW-3101 QA Fixes

### DIFF
--- a/app/components/editable-line.js
+++ b/app/components/editable-line.js
@@ -32,39 +32,31 @@ export default Ember.Component.extend(AsyncMixin, {
     });
   },
 
+  willDestroyElement() {
+    const model = this.get("model");
+    const key = this.get("key");
+
+    if (!model || !key) {
+      return;
+    }
+
+    const chagedAttributes = this.get("model").changedAttributes();
+    const changes = chagedAttributes[key];
+    if (changes) {
+      // Rollback before leaving
+      this.model.set(key, changes[0]);
+    }
+  },
+
   textarea() {
     return $(this.element).find("textarea");
   },
-
-  computedWidth: Ember.computed("value", function() {
-    if (!this.get("fitted-width") || !this.element) {
-      return "auto";
-    }
-
-    const safetyMargin = 100;
-    const el = document.createElement("div");
-    const fontSize = this.element.computedStyleMap().get("font-size");
-
-    el.textContent = this.getWithDefault("value", "");
-    el.style.display = "inline-block";
-    el.style.position = "absolute";
-    el.style.fontSize = fontSize.value + fontSize.unit;
-    el.style.visibility = "hidden";
-
-    document.body.appendChild(el);
-
-    const size = el.clientWidth;
-
-    document.body.removeChild(el);
-
-    return safetyMargin + size + "px";
-  }),
 
   disabled: Ember.computed.not("editing"),
 
   actions: {
     stopEditing() {
-      if (!this.get("editing")) {
+      if (!this.get("editing") || !this.get("value")) {
         return;
       }
 

--- a/app/controllers/items/detail.js
+++ b/app/controllers/items/detail.js
@@ -487,12 +487,14 @@ export default GoodcityController.extend(
           headerText: this.get("i18n").t("items.select_set_type")
         });
 
-        return this.runTask(async () => {
+        await this.runTask(async () => {
           await this.get("packageService").initializeSetOf(
             this.get("model"),
             code
           );
         }, ERROR_STRATEGIES.MODAL);
+
+        return this.send("addItemToCurrentSet");
       },
 
       async addItemToCurrentSet() {
@@ -512,7 +514,7 @@ export default GoodcityController.extend(
           return;
         }
 
-        this.runTask(async () => {
+        return this.runTask(async () => {
           await this.get("packageService").addToSet(pkg, packageSet);
         }, ERROR_STRATEGIES.MODAL);
       },

--- a/app/models/item.js
+++ b/app/models/item.js
@@ -41,7 +41,7 @@ export default cloudinaryUrl.extend({
   packageSet: belongsTo("package_set", {
     async: false
   }),
-  isPartOfSet: Ember.computed.bool("packageSetId"),
+  isPartOfSet: Ember.computed.bool("packageSet"),
   isBoxPallet: Ember.computed("storageType", function() {
     return (
       this.get("storageType") &&

--- a/app/services/package-service.js
+++ b/app/services/package-service.js
@@ -147,11 +147,8 @@ export default ApiBaseService.extend(NavigationAwareness, {
 
     const id = pkg.get("id");
     const packageSet = pkg.get("packageSet");
-    const payload = await this.PUT(`/packages/${id}`, {
-      package: {
-        package_set_id: null
-      }
-    });
+
+    await this.updatePackage(id, { package: { package_set_id: null } });
 
     packageSet.get("packageIds").removeObject(Number(id));
 
@@ -162,7 +159,6 @@ export default ApiBaseService.extend(NavigationAwareness, {
       packageSet.set("packageIds", []);
     }
 
-    this.get("store").pushPayload(payload);
     return this.get("store").peekRecord("item", id);
   },
 

--- a/app/templates/components/editable-line.hbs
+++ b/app/templates/components/editable-line.hbs
@@ -1,4 +1,4 @@
-<div class="gc editable-line {{if large 'large'}} {{if editing 'editing'}}" style="width: {{computedWidth}}">
+<div class="gc editable-line {{if large 'large'}} {{if editing 'editing'}}">
   {{
     auto-resize-textarea
     class=(concat "text-content editable " (if editing 'show' 'hide'))

--- a/app/templates/items/detail/_set_header.hbs
+++ b/app/templates/items/detail/_set_header.hbs
@@ -18,7 +18,7 @@
   </div>
   <div class="row">
     <div class="title">
-      {{editable-line value=model.packageSet.description model=model.packageSet large=true autosave=true fitted-width=true}}
+      {{editable-line value=model.packageSet.description key="description" model=model.packageSet large=true autosave=true fitted-width=true}}
     </div>
     <div class="subtitle">{{model.code.name}}</div>
   </div>


### PR DESCRIPTION
Fix of the following issues reported by Tim:

- If a set is removed and then immediately created again, it doesn't reappear on the UI untill the page is reloaded.
- the item search UI is not shown immediately when creating a set. See the requirement under point 3 of 'Creating a new set'
- If the description of a set is edited but the user leaves the page without selecting the save button, the changes are still saved.
- When editing the description of a set, it is possible for the description to be saved when it is empty.