### PR TITLE
GCW-3158-The list of requests on an order incorrectly shows '0' requests until the page is reloaded

### DIFF
--- a/app/routes/orders/active_items.js
+++ b/app/routes/orders/active_items.js
@@ -1,8 +1,18 @@
 import detail from "./detail";
 
 export default detail.extend({
+  async model({ order_id }) {
+    const order = await this._super(...arguments);
+    return Ember.RSVP.hash({
+      order,
+      gcRequests: this.store.query("goodcity_request", {
+        order_ids: [order_id]
+      })
+    });
+  },
+
   async setupController(controller, model = {}) {
-    await this._super(controller, model);
+    await this._super(controller, model.order);
     controller.set("ordersPkgLength", 0);
     controller.on();
   },

--- a/app/templates/orders/index.hbs
+++ b/app/templates/orders/index.hbs
@@ -21,7 +21,7 @@
           {{#infinite-list height="75vh" loadMore=(action "loadMoreOrders") as |items| }}
             <ul class="list list-activity list-offer-items">
               {{#each items as |order|}}
-                {{#link-to 'orders.active_items' order href=false}}
+                {{#link-to 'orders.active_items' order.id href=false}}
                   {{partial 'orders/order_block'}}
                 {{/link-to}}
               {{/each}}

--- a/tests/acceptance/order-redispatch-test.js
+++ b/tests/acceptance/order-redispatch-test.js
@@ -98,10 +98,16 @@ module("Acceptance: Order redispatch", {
       url: "/api/v1/auth/current_user_profil*",
       responseText: data
     });
+    MockUtils.mock({
+      url: "/api/v1/auth/current_user_profil*",
+      responseText: data
+    });
     MockUtils.mockWithRecords(
       "cancellation_reason",
       _(3).times(() => FactoryGuy.make("cancellation_reason"))
     );
+
+    MockUtils.mockWithRecords("goodcity_request", []);
 
     visit("/");
 

--- a/tests/acceptance/order-restart-processing-test.js
+++ b/tests/acceptance/order-restart-processing-test.js
@@ -115,6 +115,7 @@ module("Acceptance: Order restart processing", {
         ]
       }
     });
+    MockUtils.mockWithRecords("goodcity_request", []);
   },
   afterEach: function() {
     MockUtils.closeSession();

--- a/tests/acceptance/order-resubmit-cancel-test.js
+++ b/tests/acceptance/order-resubmit-cancel-test.js
@@ -114,6 +114,7 @@ module("Acceptance: Order resubmit", {
       "cancellation_reason",
       _(3).times(() => FactoryGuy.make("cancellation_reason"))
     );
+    MockUtils.mockWithRecords("goodcity_request", []);
   },
   afterEach: function() {
     Ember.run(App, "destroy");

--- a/tests/acceptance/order-search-list-test.js
+++ b/tests/acceptance/order-search-list-test.js
@@ -57,6 +57,7 @@ module("Acceptance: Order search list", {
       "cancellation_reason",
       _(3).times(() => FactoryGuy.make("cancellation_reason"))
     );
+    MockUtils.mockWithRecords("goodcity_request", []);
 
     visit("/");
 

--- a/tests/acceptance/order-state-awaiting-dispatch-test.js
+++ b/tests/acceptance/order-state-awaiting-dispatch-test.js
@@ -126,6 +126,7 @@ module("Acceptance: Order State awaiting dispatch", {
         ]
       }
     });
+    MockUtils.mockWithRecords("goodcity_request", []);
   },
   afterEach: function() {
     MockUtils.closeSession();

--- a/tests/acceptance/order-state-cancelled-test.js
+++ b/tests/acceptance/order-state-cancelled-test.js
@@ -126,6 +126,7 @@ module("Acceptance: Order State cancelled", {
         ]
       }
     });
+    MockUtils.mockWithRecords("goodcity_request", []);
   },
   afterEach: function() {
     MockUtils.closeSession();

--- a/tests/acceptance/order-state-close-test.js
+++ b/tests/acceptance/order-state-close-test.js
@@ -94,6 +94,7 @@ module("Acceptance: Order State closed", {
       "cancellation_reason",
       _(3).times(() => FactoryGuy.make("cancellation_reason"))
     );
+    MockUtils.mockWithRecords("goodcity_request", []);
 
     mockFindAll("designation").returns({
       json: {

--- a/tests/acceptance/order-state-dispatching-test.js
+++ b/tests/acceptance/order-state-dispatching-test.js
@@ -100,6 +100,7 @@ module("Acceptance: Order State dispatching", {
       "cancellation_reason",
       _(3).times(() => FactoryGuy.make("cancellation_reason"))
     );
+    MockUtils.mockWithRecords("goodcity_request", []);
 
     mockFindAll("designation").returns({
       json: {

--- a/tests/acceptance/order-state-processing-test.js
+++ b/tests/acceptance/order-state-processing-test.js
@@ -127,6 +127,7 @@ module("Acceptance: Order State processing", {
       "cancellation_reason",
       _(3).times(() => FactoryGuy.make("cancellation_reason"))
     );
+    MockUtils.mockWithRecords("goodcity_request", []);
   },
   afterEach: function() {
     MockUtils.closeSession();


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3158

### What does this PR do?

SInce Order is shallow loaded so `Requests` are not loaded in orders `search` page . In this PR we are making request to fetch `gc Requests` on entering order details page.