### PR TITLE
GCW-3172 Fix jquery upload error

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,8 @@
     "photoswipe": "4.1.0",
     "slick-carousel": "1.5.8",
     "socket.io-client": "~1.4.5",
-    "pickadate": "3.5.6"
+    "pickadate": "3.5.6",
+    "blueimp-load-image": "^5.12.0"
   },
   "devDependencies": {
     "localforage": "^1.4.2"

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -94,7 +94,7 @@ module.exports = function(defaults) {
     "bower_components/blueimp-file-upload/js/jquery.iframe-transport.js"
   );
   app.import("bower_components/blueimp-file-upload/js/jquery.fileupload.js");
-  app.import("bower_components/cloudinary/js/load-image.min.js");
+  app.import("bower_components/blueimp-load-image/js/load-image.all.min.js");
   app.import("bower_components/cloudinary/js/jquery.cloudinary.js");
   app.import("bower_components/cloudinary/js/canvas-to-blob.min.js");
   app.import(


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3172

### What does this PR do?

The cloudinary dependency had a file which was copied from a blueimp repo, except it was incomplete. We now pull that repo and fetch the file straight from there.