### PR TITLE
GCW-3190 Fix lost input focus

### DIFF
--- a/app/styles/templates/components/_popup_overlay.scss
+++ b/app/styles/templates/components/_popup_overlay.scss
@@ -8,8 +8,10 @@
   background-color: #002352;
   z-index: 1000;
   transform: translateY(100%);
+  pointer-events: none;
 
   &.open {
     transform: translateY(0%);
+    pointer-events: initial;
   }
 }


### PR DESCRIPTION
Disable pointer events on closed overlays. Some edge cases allowed a hidden input field to be focused