### PR TITLE
GCW-3187- Cannot search for boxes when adding to a pallet

### DIFF
--- a/app/templates/items/detail/tabs/storage_content.hbs
+++ b/app/templates/items/detail/tabs/storage_content.hbs
@@ -29,7 +29,7 @@
     open=openPackageSearch
     searchText=searchText
     associatedPackageTypes=associatedPackageTypes
-    storageTypeName=entity.storageTypeName
+    storageTypeName=item.storageTypeName
     onConfirm=(action 'openAddItemOverlay')
   }}
 </div>


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3187

### What does this PR do?

BUG: StorageTypeName was not setting which leads to only search "Package" and ignoring `Box`  during assigning Items for Box/Pallet.
