### PR TITLE
GCW-3198- Orders don't automatically load when logging in a second time

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -41,6 +41,7 @@ export default Ember.Controller.extend({
       this.get("subscription").unwire();
       this.get("notifications").send("unloadNotifications");
       this.get("session").unloadSessionData();
+      this.session.clearCache();
       this.transitionToRoute("login");
     }
   }

--- a/app/controllers/items/index.js
+++ b/app/controllers/items/index.js
@@ -22,7 +22,9 @@ export default Ember.Controller.extend(SearchMixin, {
 
   init() {
     this._super(...arguments);
-    this.cache = new Cache();
+    const cache = new Cache();
+    this.cache = cache;
+    this.session.memCache.push(cache);
   },
 
   /**

--- a/app/controllers/items/index.js
+++ b/app/controllers/items/index.js
@@ -8,6 +8,7 @@ import SearchMixin from "stock/mixins/search_resource";
  * @augments ember/Controller
  */
 export default Ember.Controller.extend(SearchMixin, {
+  session: Ember.inject.service(),
   queryParams: ["searchInput", "itemSetId"],
   itemSetId: null,
   isMobileApp: config.cordova.enabled,
@@ -22,9 +23,8 @@ export default Ember.Controller.extend(SearchMixin, {
 
   init() {
     this._super(...arguments);
-    const cache = new Cache();
-    this.cache = cache;
-    this.session.memCache.push(cache);
+    this.cache = new Cache();
+    this.get("session").memCache.push(this.cache);
   },
 
   /**

--- a/app/controllers/orders/index.js
+++ b/app/controllers/orders/index.js
@@ -9,6 +9,7 @@ import SearchMixin from "stock/mixins/search_resource";
  * @augments ember/Controller
  */
 export default Ember.Controller.extend(SearchMixin, {
+  session: Ember.inject.service(),
   /**
    * @property {Boolean} SearchMixin configuration
    **/
@@ -20,9 +21,8 @@ export default Ember.Controller.extend(SearchMixin, {
 
   init() {
     this._super(...arguments);
-    const cache = new Cache();
-    this.cache = cache;
-    this.session.memCache.push(cache);
+    this.cache = new Cache();
+    this.get("session").memCache.push(this.cache);
   },
 
   searchProps: {

--- a/app/controllers/orders/index.js
+++ b/app/controllers/orders/index.js
@@ -20,7 +20,9 @@ export default Ember.Controller.extend(SearchMixin, {
 
   init() {
     this._super(...arguments);
-    this.cache = new Cache();
+    const cache = new Cache();
+    this.cache = cache;
+    this.session.memCache.push(cache);
   },
 
   searchProps: {

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -6,6 +6,7 @@ export default Ember.Service.extend({
   authToken: Ember.computed.localStorage(),
   otpAuthKey: Ember.computed.localStorage(),
   language: Ember.computed.localStorage(),
+  memCache: [],
   isLoggedIn: Ember.computed.notEmpty("authToken"),
   store: Ember.inject.service(),
   deviceId: Math.random()
@@ -25,6 +26,12 @@ export default Ember.Service.extend({
     this.set("authToken", null);
     this.set("language", null);
     this.set("otpAuthKey", null);
+  },
+
+  clearCache() {
+    const memCache = this.get("memCache");
+    memCache.map(cache => (cache.cache = {}));
+    memCache.set("memCache", []);
   },
 
   unloadSessionData() {

--- a/tests/controller/items/index-test.js
+++ b/tests/controller/items/index-test.js
@@ -6,6 +6,7 @@ import Ember from "ember";
 var App;
 
 moduleFor("controller:items.index", "items.index controller", {
+  needs: ["service:session"],
   beforeEach: function() {
     App = startApp({}, 2);
     TestHelper.setup();

--- a/tests/controller/order-index-test.js
+++ b/tests/controller/order-index-test.js
@@ -1,7 +1,7 @@
 import { test, moduleFor } from "ember-qunit";
 
 moduleFor("controller:orders.index", "orders.index controller", {
-  needs: ["service:i18n"]
+  needs: ["service:i18n", "service:session"]
 });
 
 test("checking default set properties", function(assert) {


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3198

### What does this PR do?

On logout cache was not getting cleared. So, on going to orders or Items index  search page. It tried to show cached key data but data was not available in store because of logout.

This PR clears up cache on logout.