### PR TITLE
GCW-3182-Issues with the Charity/Orders page.

### DIFF
--- a/app/adapters/gc_organisation.js
+++ b/app/adapters/gc_organisation.js
@@ -1,24 +1,5 @@
 import ApplicationAdapter from "./application";
-import config from "stock/config/environment";
-import { pluralize } from "ember-inflector";
 
 export default ApplicationAdapter.extend({
-  coalesceFindRequests: true,
-
-  urlForQuery: function(query, modelName) {
-    const { slug, organisationId } = query;
-    const { NAMESPACE, API_HOST_URL } = config.APP;
-
-    if (slug && organisationId) {
-      delete query.organisationId;
-      delete query.slug;
-      return `${API_HOST_URL}/${NAMESPACE}/${pluralize(
-        modelName
-      )}/${organisationId}/${slug}`;
-    } else if (slug) {
-      return `${API_HOST_URL}/${NAMESPACE}/${pluralize(modelName)}/${slug}`;
-    } else {
-      return this._super(...arguments);
-    }
-  }
+  coalesceFindRequests: true
 });

--- a/app/adapters/gc_organisation.js
+++ b/app/adapters/gc_organisation.js
@@ -1,5 +1,24 @@
 import ApplicationAdapter from "./application";
+import config from "stock/config/environment";
+import { pluralize } from "ember-inflector";
 
 export default ApplicationAdapter.extend({
-  coalesceFindRequests: true
+  coalesceFindRequests: true,
+
+  urlForQuery: function(query, modelName) {
+    const { slug, organisationId } = query;
+    const { NAMESPACE, API_HOST_URL } = config.APP;
+
+    if (slug && organisationId) {
+      delete query.organisationId;
+      delete query.slug;
+      return `${API_HOST_URL}/${NAMESPACE}/${pluralize(
+        modelName
+      )}/${organisationId}/${slug}`;
+    } else if (slug) {
+      return `${API_HOST_URL}/${NAMESPACE}/${pluralize(modelName)}/${slug}`;
+    } else {
+      return this._super(...arguments);
+    }
+  }
 });

--- a/app/controllers/organisations/orders.js
+++ b/app/controllers/organisations/orders.js
@@ -4,27 +4,18 @@ import SearchMixin from "stock/mixins/search_resource";
 
 export default Ember.Controller.extend(SearchMixin, {
   gcOrganisationUsers: null,
+  organisationService: Ember.inject.service(),
 
   actions: {
-    /**
-     * Load the next page of the list
-     *
-     * @memberof OrdersSearchController
-     * @param {number} pageNo the page to load
-     * @returns {Promise<Order[]>}
-     */
     loadOrders(pageNo) {
       const cache = this.get("cache");
       const params = this.trimQuery(
-        _.merge(
-          {
-            slug: "organisation_orders",
-            organisationId: this.get("model.id")
-          },
-          this.getPaginationQuery(pageNo)
-        )
+        _.merge({}, this.getPaginationQuery(pageNo))
       );
-      return this.get("store").query("gcOrganisation", params);
+      return this.get("organisationService").getOrganisationOrders(
+        this.get("model.id"),
+        params
+      );
     }
   }
 });

--- a/app/controllers/organisations/orders.js
+++ b/app/controllers/organisations/orders.js
@@ -8,12 +8,12 @@ export default Ember.Controller.extend(SearchMixin, {
 
   actions: {
     loadOrders(pageNo) {
-      const cache = this.get("cache");
+      const organisationId = this.get("model.id");
       const params = this.trimQuery(
         _.merge({}, this.getPaginationQuery(pageNo))
       );
       return this.get("organisationService").getOrganisationOrders(
-        this.get("model.id"),
+        organisationId,
         params
       );
     }

--- a/app/controllers/organisations/orders.js
+++ b/app/controllers/organisations/orders.js
@@ -1,6 +1,30 @@
 import Ember from "ember";
+import _ from "lodash";
+import SearchMixin from "stock/mixins/search_resource";
 
-export default Ember.Controller.extend({
+export default Ember.Controller.extend(SearchMixin, {
   gcOrganisationUsers: null,
-  filteredResults: Ember.computed.alias('model.designations')
+
+  actions: {
+    /**
+     * Load the next page of the list
+     *
+     * @memberof OrdersSearchController
+     * @param {number} pageNo the page to load
+     * @returns {Promise<Order[]>}
+     */
+    loadOrders(pageNo) {
+      const cache = this.get("cache");
+      const params = this.trimQuery(
+        _.merge(
+          {
+            slug: "organisation_orders",
+            organisationId: this.get("model.id")
+          },
+          this.getPaginationQuery(pageNo)
+        )
+      );
+      return this.get("store").query("gcOrganisation", params);
+    }
+  }
 });

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -30,7 +30,7 @@ export default {
   save: "Save",
   details: "Details",
   orders: "Orders",
-  users: "Users",
+  users_count: "Users",
   menu: "Menu",
   search_organisation: "Search Organisation",
   not_now: "Not Now",

--- a/app/locales/zh-tw/translations.js
+++ b/app/locales/zh-tw/translations.js
@@ -29,7 +29,7 @@ export default {
   details: "詳情",
   orders_in_process: "Orders In Process",
   orders: "訂單",
-  users: "用戶",
+  users_count: "用戶",
   menu: "主目錄",
   search_organisation: "搜尋機構",
   not_now: "稍後",

--- a/app/models/gc_organisation.js
+++ b/app/models/gc_organisation.js
@@ -1,20 +1,17 @@
-import Model from 'ember-data/model';
-import attr from 'ember-data/attr';
+import Model from "ember-data/model";
+import attr from "ember-data/attr";
 import Ember from "ember";
-import { hasMany } from 'ember-data/relationships';
+import { hasMany } from "ember-data/relationships";
 export default Model.extend({
-  nameEn: attr('string'),
-  nameZhTw: attr('string'),
-  descriptionEn: attr('string'),
-  descriptionZhTw: attr('string'),
-  website: attr('string'),
-  registration: attr('string'),
-  usersCount: Ember.computed.alias('organisationsUsers.length'),
+  nameEn: attr("string"),
+  nameZhTw: attr("string"),
+  descriptionEn: attr("string"),
+  descriptionZhTw: attr("string"),
+  website: attr("string"),
+  registration: attr("string"),
+  ordersCount: attr("string"),
+  usersCount: Ember.computed.alias("organisationsUsers.length"),
 
-  organisationsUsers: hasMany('organisations_user', { async: false }),
-  designations: hasMany('designation', { async: false }),
-
-  ordersCount: Ember.computed('designations.[]', function(){
-    return this.get('designations.length');
-  })
+  organisationsUsers: hasMany("organisations_user", { async: false }),
+  designations: hasMany("designation", { async: false })
 });

--- a/app/routes/organisations/orders.js
+++ b/app/routes/organisations/orders.js
@@ -1,4 +1,8 @@
-import OrganisationRoute from './../organisation';
+import OrganisationRoute from "./../organisation";
 
 export default OrganisationRoute.extend({
+  setupController(controller, model) {
+    this._super(controller, model);
+    controller.on();
+  }
 });

--- a/app/services/organisation-service.js
+++ b/app/services/organisation-service.js
@@ -1,0 +1,21 @@
+import Ember from "ember";
+import ApiBaseService from "./api-base-service";
+import _ from "lodash";
+import { toID } from "stock/utils/helpers";
+
+export default ApiBaseService.extend({
+  store: Ember.inject.service(),
+
+  async getOrganisationOrders(order, opts = {}) {
+    const store = this.get("store");
+    const pagination = _.pick(opts, ["page", "per_page"]);
+    const id = toID(order);
+
+    const data = await this.GET(
+      `/gc_organisations/${id}/organisation_orders`,
+      pagination
+    );
+    store.pushPayload(data);
+    return store.peekRecord("gc_organisation", id).get("designations");
+  }
+});

--- a/app/styles/templates/organisations/_search_organisations.scss
+++ b/app/styles/templates/organisations/_search_organisations.scss
@@ -49,3 +49,11 @@
 .organisation_search_result{
   padding-top: 3rem;
 }
+
+.organisation_orders {
+  padding-top: 0;
+
+  .search {
+    margin-top: 0;
+  }
+}

--- a/app/templates/organisations/_organisation_tabs.hbs
+++ b/app/templates/organisations/_organisation_tabs.hbs
@@ -16,7 +16,7 @@
 
         {{#link-to 'organisations.users' model.id tagName="dd" classNames="small-4 columns text-center"}}
           {{#link-to 'organisations.users' model.id}}
-            <div> {{t 'users'}} ({{gcOrganisationUsers.length}})</div>
+            <div> {{t 'users_count'}} ({{gcOrganisationUsers.length}})</div>
           {{/link-to}}
         {{/link-to}}
       </dl>

--- a/app/templates/organisations/orders.hbs
+++ b/app/templates/organisations/orders.hbs
@@ -7,7 +7,7 @@
     {{#if displayResults}}
       {{#infinite-list height="75vh" loadMore=(action "loadOrders") as |orders| }}
         <ul class="list list-activity">
-          {{#each loadOrders as |order|}}
+          {{#each orders as |order|}}
             {{#link-to 'orders.active_items' order.id href=false}}
               {{partial 'orders/order_block'}}
             {{/link-to}}

--- a/app/templates/organisations/orders.hbs
+++ b/app/templates/organisations/orders.hbs
@@ -4,12 +4,16 @@
   {{partial 'organisations/organisation_tabs'}}
 
   <div class="row search">
-    <ul class="list list-activity">
-      {{#each filteredResults as |order|}}
-        {{#link-to 'orders.active_items' order.id href=false}}
-          {{partial 'orders/order_block'}}
-        {{/link-to}}
-      {{/each}}
-    </ul>
+    {{#if displayResults}}
+      {{#infinite-list height="75vh" loadMore=(action "loadOrders") as |orders| }}
+        <ul class="list list-activity">
+          {{#each loadOrders as |order|}}
+            {{#link-to 'orders.active_items' order.id href=false}}
+              {{partial 'orders/order_block'}}
+            {{/link-to}}
+          {{/each}}
+        </ul>
+      {{/infinite-list}}
+    {{/if}}
   </div>
 </section>

--- a/app/templates/organisations/orders.hbs
+++ b/app/templates/organisations/orders.hbs
@@ -1,6 +1,6 @@
 {{partial 'organisations/nav_bar'}}
 
-<section class="main-section">
+<section class="main-section orders_search_result organisation_orders">
   {{partial 'organisations/organisation_tabs'}}
 
   <div class="row search">

--- a/tests/unit/model/gc_organisation-test.js
+++ b/tests/unit/model/gc_organisation-test.js
@@ -1,35 +1,38 @@
-import { test, moduleForModel } from 'ember-qunit';
-import FactoryGuy from 'ember-data-factory-guy';
-import startApp from '../../helpers/start-app';
-import TestHelper from 'ember-data-factory-guy/factory-guy-test-helper';
-import Ember from 'ember';
+import { test, moduleForModel } from "ember-qunit";
+import FactoryGuy from "ember-data-factory-guy";
+import startApp from "../../helpers/start-app";
+import TestHelper from "ember-data-factory-guy/factory-guy-test-helper";
+import Ember from "ember";
 
 var App;
 
-moduleForModel('gc_organisation', 'GcOrganisation model', {
-  needs: ['model:organisations_user', 'model:designation'],
+moduleForModel("gc_organisation", "GcOrganisation model", {
+  needs: ["model:organisations_user", "model:designation"],
 
   beforeEach: function() {
     App = startApp({}, 2);
     TestHelper.setup();
   },
   afterEach: function() {
-    Ember.run(function() { TestHelper.teardown(); });
-    Ember.run(App, 'destroy');
+    Ember.run(function() {
+      TestHelper.teardown();
+    });
+    Ember.run(App, "destroy");
   }
 });
 
-test('check attributes', function(assert){
+test("check attributes", function(assert) {
   assert.expect(6);
 
   var model = this.subject();
 
-  var nameEn = Object.keys(model.toJSON()).indexOf('nameEn') > -1;
-  var nameZhTw = Object.keys(model.toJSON()).indexOf('nameZhTw') > -1;
-  var descriptionEn = Object.keys(model.toJSON()).indexOf('descriptionEn') > -1;
-  var descriptionZhTw = Object.keys(model.toJSON()).indexOf('descriptionZhTw') > -1;
-  var website = Object.keys(model.toJSON()).indexOf('website') > -1;
-  var registration = Object.keys(model.toJSON()).indexOf('registration') > -1;
+  var nameEn = Object.keys(model.toJSON()).indexOf("nameEn") > -1;
+  var nameZhTw = Object.keys(model.toJSON()).indexOf("nameZhTw") > -1;
+  var descriptionEn = Object.keys(model.toJSON()).indexOf("descriptionEn") > -1;
+  var descriptionZhTw =
+    Object.keys(model.toJSON()).indexOf("descriptionZhTw") > -1;
+  var website = Object.keys(model.toJSON()).indexOf("website") > -1;
+  var registration = Object.keys(model.toJSON()).indexOf("registration") > -1;
 
   assert.ok(nameEn);
   assert.ok(nameZhTw);
@@ -39,22 +42,16 @@ test('check attributes', function(assert){
   assert.ok(registration);
 });
 
-test('Relationships with other models', function(assert){
+test("Relationships with other models", function(assert) {
   assert.expect(2);
 
-  var gc_organisation = this.store().modelFor('gc_organisation');
+  var gc_organisation = this.store().modelFor("gc_organisation");
 
-  var relationshipWithContact = Ember.get(gc_organisation, 'relationshipsByName').get('organisationsUsers');
+  var relationshipWithContact = Ember.get(
+    gc_organisation,
+    "relationshipsByName"
+  ).get("organisationsUsers");
 
-  assert.equal(relationshipWithContact.key, 'organisationsUsers');
-  assert.equal(relationshipWithContact.kind, 'hasMany');
+  assert.equal(relationshipWithContact.key, "organisationsUsers");
+  assert.equal(relationshipWithContact.kind, "hasMany");
 });
-
-test('ordersCount returns total order count associated with organisation', function(assert){
-  var orders = FactoryGuy.makeList('designation', 2);
-
-  var model = this.subject({ designations: orders });
-
-  assert.equal(model.get('ordersCount'), 2);
-});
-


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3182

### What does this PR do?

#### Issues under Organisation section:

Till now `orders` count for organisation was calculated according to `orders` already loaded in ember-data for any particular organisation.

There was wrong `Orders Count` on:
-  Searched organisation results.
-  On selecting organisation, the count on the `Orders` tab.

This PR fixes:
-  `orders` count dependency on ember-data is removed and fetching `ordersCount` as part of `organisation` model data.
-   Separate  endpoint  endpoint for fetching organisation orders with pagination.
-   CSS fixes for `orders` list.

Please review this PR.