### PR TITLE
GCW-3218 set default-quantity as available while moving item to box

### DIFF
--- a/app/models/packages_location.js
+++ b/app/models/packages_location.js
@@ -4,7 +4,6 @@ import attr from "ember-data/attr";
 import { belongsTo } from "ember-data/relationships";
 
 export default Model.extend({
-  defaultAddableQuantity: attr("number", { defaultValue: 0 }),
   packageId: attr("number"),
   itemId: attr("number"),
   quantity: attr("number"),
@@ -12,6 +11,8 @@ export default Model.extend({
 
   location: belongsTo("location", { async: false }),
   item: belongsTo("item", { async: false }),
+
+  defaultAddableQuantity: Ember.computed.oneWay("quantity"),
 
   quantityToMove: Ember.computed("quantity", function() {
     return this.get("quantity");


### PR DESCRIPTION
### Ticket Link: 
https://jira.crossroads.org.hk/browse/GCW-3218

### What does this PR do?
Currently when an item is moved to a box the default quantity to move is 0, after this change, it will default to the full available quantity of the item.