### PR TITLE
GCW-3170 handle unread-count on notifications screen

### DIFF
--- a/app/controllers/my_notifications.js
+++ b/app/controllers/my_notifications.js
@@ -50,18 +50,25 @@ export default Ember.Controller.extend({
 
     let notif = notifications.findBy("key", MSG_KEY(msg));
 
-    if (notif) {
-      // Update existing one
-      notifications.removeObject(notif);
-      msg.set("unreadCount", +notif.get("unreadCount") + 1);
-      notif.get("messages").addObject(msg);
-    } else {
-      // Create new one
-      msg.set("unreadCount", 1);
-      notif = this.messagesToNotification([msg]);
+    if (notification.operation === "create") {
+      if (notif) {
+        // Update existing one
+        notifications.removeObject(notif);
+        msg.set("unreadCount", +notif.get("unreadCount") + 1);
+        notif.get("messages").addObject(msg);
+      } else {
+        // Create new one
+        msg.set("unreadCount", 1);
+        notif = this.messagesToNotification([msg]);
+      }
+      notifications.insertAt(0, notif);
+    } else if (
+      notification.operation === "update" &&
+      notif &&
+      notification.record.state === "read"
+    ) {
+      notif.set("unreadCount", 0);
     }
-
-    notifications.insertAt(0, notif);
   },
 
   /**

--- a/app/services/messages.js
+++ b/app/services/messages.js
@@ -15,11 +15,16 @@ export default Ember.Service.extend({
     this.get("subscription").on("change:message", this, this.onNewNotification);
   },
 
-  onNewNotification({ record: { id } }) {
-    const msg = this.get("store").peekRecord("message", id);
+  onNewNotification(notification) {
+    const msg = this.get("store").peekRecord("message", notification.record.id);
 
-    if (msg.get("isUnread")) {
+    if (notification.operation === "create" && msg.get("isUnread")) {
       this._incrementCount();
+    } else if (
+      notification.operation === "update" &&
+      notification.record.state === "read"
+    ) {
+      this._decrementCount();
     }
   },
 


### PR DESCRIPTION
### Ticket Link: 
https://jira.crossroads.org.hk/browse/GCW-3170

### What does this PR do?
Fix Issue: when a comment is read from a different platform or a different browser tab, the unread alerts record doesn't update until the page is reloaded.