### PR TITLE
GCW-2957-Added fix for dropbox in management quota

### DIFF
--- a/app/controllers/appointments.js
+++ b/app/controllers/appointments.js
@@ -130,10 +130,20 @@ export default GoodcityController.extend({
 
     showSpecial() {
       this.set("selectedTab", "special");
+      _.map(this.get("specialSlotsByDate"), days => {
+        if (days.get("showOptionsMenu")) {
+          days.set("showOptionsMenu", !days.get("showOptionsMenu"));
+        }
+      });
     },
 
     showDefault() {
       this.set("selectedTab", "presets");
+      _.map(this.get("presetsByWeekDay"), days => {
+        if (days.get("showOptionsMenu")) {
+          days.set("showOptionsMenu", !days.get("showOptionsMenu"));
+        }
+      });
     },
 
     toggleOptionsMenu(obj) {

--- a/app/controllers/appointments.js
+++ b/app/controllers/appointments.js
@@ -130,20 +130,16 @@ export default GoodcityController.extend({
 
     showSpecial() {
       this.set("selectedTab", "special");
-      _.map(this.get("specialSlotsByDate"), days => {
-        if (days.get("showOptionsMenu")) {
-          days.set("showOptionsMenu", !days.get("showOptionsMenu"));
-        }
-      });
+      this.get("specialSlotsByDate").forEach(days =>
+        days.set("showOptionsMenu", false)
+      );
     },
 
     showDefault() {
       this.set("selectedTab", "presets");
-      _.map(this.get("presetsByWeekDay"), days => {
-        if (days.get("showOptionsMenu")) {
-          days.set("showOptionsMenu", !days.get("showOptionsMenu"));
-        }
-      });
+      this.get("presetsByWeekDay").forEach(days =>
+        days.set("showOptionsMenu", false)
+      );
     },
 
     toggleOptionsMenu(obj) {


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2957

### What does this PR do?
On the 'Manage Appointment Quotas' page, after selecting a 3 vertical dots icon on a day and opening the dropdown box, if a user goes to the 'Special Dates' tab and returns to the 'Default Quotas' tab, the dropdown box will still be open fix