### PR TITLE
GCW-2956-Fix for breaking of icons in small screens for appointment quotas page

### DIFF
--- a/app/styles/templates/_appointments.scss
+++ b/app/styles/templates/_appointments.scss
@@ -38,6 +38,9 @@
     }
   }
 
+  .quota-qty {
+    font-size: 1rem;
+  }
   .settings-section {
     display: none;
 
@@ -93,12 +96,12 @@
 
     // Icons
 
-    i.fa {
+    i  {
       font-size: 1rem;
     }
 
-    .delete-btn i.fa {
-      color: #e25956;
+    .delete-btn {
+      font-size: 1rem;
     }
 
     // Buttons

--- a/app/templates/settings/appointments/_preset_quotas_tab.hbs
+++ b/app/templates/settings/appointments/_preset_quotas_tab.hbs
@@ -48,7 +48,7 @@
             <div class="columns small-4 text-align-right">
               <i class="decrease-quota" {{ action 'decreaseQuotaOf' item.record }}>{{fa-icon 'minus-circle'}}</i>
             </div>
-            <div class="columns small-4">
+            <div class="columns small-4 quota-qty">
               {{ item.record.quota }}
             </div>
             <div class="columns small-4 text-align-left">

--- a/app/templates/settings/appointments/_special_day_quotas_tab.hbs
+++ b/app/templates/settings/appointments/_special_day_quotas_tab.hbs
@@ -82,7 +82,7 @@
             <div class="columns small-4 text-align-right">
               <i class="decrease-quota" {{ action 'decreaseQuotaOf' slot.record }}>{{fa-icon 'minus-circle'}}</i>
             </div>
-            <div class="columns small-4">
+            <div class="columns small-4 quota-qty">
               {{ slot.record.quota }}
             </div>
             <div class="columns small-4 text-align-left">


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2956

### What does this PR do?
In small screens the 'Manage Appointment Quotas' page, it's difficult to select the 3 vertical dots icon, the + and - buttons, and the x button fix .

### Screenshots
![Screen Shot 2020-08-24 at 12 36 39 PM](https://user-images.githubusercontent.com/60003954/91014180-90b20700-e606-11ea-9362-b2cae9f15c62.png)


