### PR TITLE
:bug: GCW-3269 live updates don't re-trigger a destroy action

### DIFF
--- a/app/models/item.js
+++ b/app/models/item.js
@@ -111,7 +111,7 @@ export default cloudinaryUrl.extend(GradeMixin, {
   offer: belongsTo("offer", { async: false }),
   imageIds: attr(),
   images: hasMany("image", {
-    async: true
+    async: false
   }),
 
   messages: hasMany("message", {

--- a/app/services/subscription.js
+++ b/app/services/subscription.js
@@ -286,7 +286,7 @@ export default Ember.Service.extend(Ember.Evented, AsyncMixin, {
       case "delete":
         let existingItem = this.get("store").peekRecord(type, record.id);
         if (existingItem) {
-          this.get("store").unloadRecord(existingItem);
+          existingItem.unloadRecord();
         }
         break;
       default:

--- a/app/services/subscription.js
+++ b/app/services/subscription.js
@@ -286,7 +286,7 @@ export default Ember.Service.extend(Ember.Evented, AsyncMixin, {
       case "delete":
         let existingItem = this.get("store").peekRecord(type, record.id);
         if (existingItem) {
-          existingItem.destroyRecord();
+          this.get("store").unloadRecord(existingItem);
         }
         break;
       default:


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3296

### What does this PR do?

This bug was introduced recently, when the subscription code received a "delete" action it would call the `destroyRecord` method. Essentially, tried to delete a record which was already deleted, which caused the bug.

This restores the code as it was.

### Impacted Areas

Stock live updates
