### PR TITLE
GCW-3275 Verify org_user status during finish_processing step

### DIFF
--- a/app/controllers/orders/detail.js
+++ b/app/controllers/orders/detail.js
@@ -122,7 +122,7 @@ export default GoodcityController.extend(AsyncMixin, SearchMixin, {
   ),
 
   organisationsUser: Ember.computed(
-    "model.{createdBy,isGoodCityOrder,}",
+    "model.{createdBy,isGoodCityOrder}",
     "model.createdBy.organisationsUsers.@each.{status,organisationId}",
     "model.createdBy.organisationsUsers.[]",
     "model.{gcOrganisation,isGoodCityOrder}",
@@ -234,7 +234,7 @@ export default GoodcityController.extend(AsyncMixin, SearchMixin, {
 
   async verifyOrgApproval(cb) {
     if (
-      !this.get("model.isGoodCityOrder") ||
+      !this.get("organisationsUser") ||
       this.get("organisationsUser.isApproved")
     ) {
       return cb();
@@ -360,7 +360,9 @@ export default GoodcityController.extend(AsyncMixin, SearchMixin, {
           this.send("promptCloseOrderModel", order, actionName);
           break;
         case "finish_processing":
-          this.send("verifyChecklistAndChangeState", order, actionName);
+          this.verifyOrgApproval(() => {
+            this.send("verifyChecklistAndChangeState", order, actionName);
+          });
           break;
         case "start_dispatching":
           this.send("verifyChecklistAndChangeState", order, actionName);

--- a/app/templates/orders/contact_summary.hbs
+++ b/app/templates/orders/contact_summary.hbs
@@ -116,14 +116,20 @@
           </div>
         </div>
 
-        <div class="row">
-          <div class="small-4 columns">
-            {{t "order_contact_summary.approval_status"}}
+        {{#if organisationsUser}}
+          <div class="row">
+            <div class="small-4 columns">
+              {{t "order_contact_summary.approval_status"}}
+            </div>
+            <div id="contact_name" class="small-8 columns important {{unless organisationsUser.isActive 'warn'}}">
+              {{#if organisationsUser.status}}
+                {{t (concat "order_contact_summary.status_" organisationsUser.status)}}
+              {{else}}
+                  N/A
+              {{/if}}
+            </div>
           </div>
-          <div id="contact_name" class="small-8 columns important {{unless organisationsUser.isActive 'warn'}}">
-            {{t (concat "order_contact_summary.status_" organisationsUser.status)}}
-          </div>
-        </div>
+        {{/if}}
 
         <div class="row">
           <div class="small-4 columns">


### PR DESCRIPTION
Based on comments from Tim on https://jira.crossroads.org.hk/browse/GCW-3275

- Added verification step
- Do not show organisations_user status row for shipments
