### PR TITLE
GCW-3339-Error pops up when a empty message is send fix

### DIFF
--- a/app/mixins/messages_base.js
+++ b/app/mixins/messages_base.js
@@ -35,6 +35,9 @@ export default Ember.Mixin.create({
   },
 
   createMessage(values) {
+    if (!values) {
+      return;
+    }
     var message = this.store.createRecord("message", values);
     message
       .save()


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3339

### What does this PR do?

BUG:  While on the 'User' or 'Staff' tab of an order, selecting the 'Send' button while the text field is empty causes the 'The backend responded with an error' pop-up message to appear.
