### PR TITLE
Fix: Catch error properly when deleting a beneficiary

### DIFF
--- a/app/controllers/orders/client_summary.js
+++ b/app/controllers/orders/client_summary.js
@@ -1,10 +1,11 @@
 import detail from "./detail";
 import Ember from "ember";
-import AsyncMixin from "stock/mixins/async";
+import AsyncMixin, { ERROR_STRATEGIES } from "stock/mixins/async";
 
 export default detail.extend(AsyncMixin, {
   showBeneficiaryModal: false,
   designationService: Ember.inject.service(),
+  orderService: Ember.inject.service(),
 
   titles: Ember.computed(function() {
     return [
@@ -38,20 +39,10 @@ export default detail.extend(AsyncMixin, {
 
     deleteBeneficiary() {
       const order = this.get("model");
-      const beneficiary = order.get("beneficiary");
 
-      if (beneficiary) {
-        this.showLoadingSpinner();
-        beneficiary
-          .destroyRecord()
-          .then(() => {
-            order.set("beneficiary", null);
-            return order.save();
-          })
-          .finally(() => {
-            this.hideLoadingSpinner();
-          });
-      }
+      this.runTask(() => {
+        return this.get("orderService").deleteBeneficiaryOf(order);
+      }, ERROR_STRATEGIES.MODAL);
     }
   }
 });

--- a/app/services/order-service.js
+++ b/app/services/order-service.js
@@ -19,5 +19,25 @@ export default ApiBaseService.extend({
 
   cancelOrder(order, reason) {
     return this.changeOrderState(order, "cancel", reason);
+  },
+
+  /**
+   * Deletes the beneficiary of an order (if it exists)
+   *
+   * @param {Order} order
+   * @returns {Order}
+   */
+  async deleteBeneficiaryOf(order) {
+    if (!order.get("beneficiaryId")) {
+      return order;
+    }
+
+    await this.DELETE(`/beneficiaries/${order.get("beneficiaryId")}`);
+
+    order.get("beneficiary").unloadRecord();
+    order.set("beneficiary", null);
+    order.set("beneficiaryId", null);
+
+    return order;
   }
 });


### PR DESCRIPTION
Using `destroyRecord` obfuscates the underlying error message. I simply replaced it with an ajax call