### PR TITLE
GCW-3350-Stock: When designating an item from the Action Menu on an item's page, after selecting the location the user must open the Action Menu again to bring up the confirmation pop-up.

### DIFF
--- a/app/templates/items/sticky_footer.hbs
+++ b/app/templates/items/sticky_footer.hbs
@@ -51,7 +51,7 @@
         </div>
         <div class="small-6 columns">
           <ul>
-            <li class="menu" {{action (toggle this "showExtendedFooterMenu")}}>
+            <li class="menu">
               {{#goodcity/designate-link pkg=item}}
                 <i>{{fa-icon 'shopping-basket'}}</i> {{t "item.designate"}}
               {{/goodcity/designate-link}}


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3350

### What does this PR do?

Fixes bug of displaying `designate-form` on item-details.