### PR TITLE
GCW-3360- Using browser/device 'back' button breaks with inline edits

### DIFF
--- a/app/components/numeric-inline-input.js
+++ b/app/components/numeric-inline-input.js
@@ -103,5 +103,9 @@ export default Ember.TextField.extend({
 
   click() {
     this.addCssStyle();
+  },
+
+  willDestroyElement() {
+    this.destroy();
   }
 });


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3360

### What does this PR do?

`willDestroyElement` added to destroy component on page change.