### PR TITLE
FIX: Introduce codes preloading for stocktake page

### DIFF
--- a/app/components/goodcity/code-search-overlay.js
+++ b/app/components/goodcity/code-search-overlay.js
@@ -1,7 +1,7 @@
 import Ember from "ember";
 import _ from "lodash";
 import SearchMixin from "stock/mixins/search_resource";
-import AsyncMixin, { ERROR_STRATEGIES } from "stock/mixins/async";
+import AsyncMixin, { ASYNC_BEHAVIOURS } from "stock/mixins/async";
 
 /**
  * An overlay that pops up from the bottom of the screen, allowing the user
@@ -14,6 +14,7 @@ import AsyncMixin, { ERROR_STRATEGIES } from "stock/mixins/async";
  */
 export default Ember.Component.extend(SearchMixin, AsyncMixin, {
   store: Ember.inject.service(),
+  packageTypeService: Ember.inject.service(),
   filter: "",
   searchText: "",
   fetchMoreResult: true,
@@ -24,15 +25,9 @@ export default Ember.Component.extend(SearchMixin, AsyncMixin, {
   },
 
   async didRender() {
-    const hasData = this.get("store")
-      .peekAll("code")
-      .get("length");
-
-    if (this.get("open") && !hasData) {
-      await this.runTask(async () => {
-        await this.get("store").query("code", { stock: true });
-      }, ERROR_STRATEGIES.MODAL);
-    }
+    await this.runTask(() => {
+      return this.get("packageTypeService").preload();
+    }, ASYNC_BEHAVIOURS.SILENT_DEPENDENCY);
   },
 
   allPackageTypes: Ember.computed("open", "subsetPackageTypes", function() {

--- a/app/mixins/async.js
+++ b/app/mixins/async.js
@@ -49,6 +49,10 @@ export const ASYNC_BEHAVIOURS = {
   LOUD: {
     showSpinner: true,
     errorStrategy: ERROR_STRATEGIES.MODAL
+  },
+  SILENT_DEPENDENCY: {
+    showSpinner: false,
+    errorStrategy: ERROR_STRATEGIES.MODAL
   }
 };
 

--- a/app/routes/stocktakes/detail.js
+++ b/app/routes/stocktakes/detail.js
@@ -2,8 +2,11 @@ import AuthorizeRoute from "../authorize";
 import Ember from "ember";
 
 export default AuthorizeRoute.extend({
+  packageTypeService: Ember.inject.service(),
+
   model({ stocktake_id }) {
     return Ember.RSVP.hash({
+      codes: this.get("packageTypeService").preload(),
       stocktake: this.store.findRecord("stocktake", stocktake_id)
     });
   },

--- a/app/routes/stocktakes/index.js
+++ b/app/routes/stocktakes/index.js
@@ -2,8 +2,11 @@ import AuthorizeRoute from "../authorize";
 import Ember from "ember";
 
 export default AuthorizeRoute.extend({
+  packageTypeService: Ember.inject.service(),
+
   model() {
     return Ember.RSVP.hash({
+      codes: this.get("packageTypeService").preload(),
       stocktakes: this.store.findAll("stocktake", { reload: true })
     });
   },

--- a/app/services/package-type-service.js
+++ b/app/services/package-type-service.js
@@ -1,5 +1,6 @@
 import Ember from "ember";
 import _ from "lodash";
+import { cached } from "../utils/cache";
 
 // @todo: unify code and pacakge_type under 'package_type'
 const MODEL_NAME = "code";
@@ -39,6 +40,10 @@ export default Ember.Service.extend({
 
     return deferred.promise;
   },
+
+  preload: cached(function() {
+    return this.get("store").query("code", { stock: true });
+  }),
 
   parentsOf(packageType) {
     const hierarchy = this.get("hierarchy");


### PR DESCRIPTION
The package-type preloading was recently removed, which caused parts of the app to break.

I made a cached preload method that can be called anywhere, and added it to the stocktake page.

cc - @bharat619 could you check this : )