### PR TITLE
Remove dependency of ember-scroll-to-bottom which is deprecated and it causes build failure

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,4 +1,3 @@
-@import "scroll-to-bottom";
 @import "settings";
 @import "bower_components/foundation/scss/foundation";
 @import "fonts";

--- a/app/templates/order/appointment_details.hbs
+++ b/app/templates/order/appointment_details.hbs
@@ -1,7 +1,3 @@
-{{!-- {{#if isMobileApp}}
-  {{scroll-to-bottom }}
-{{/if}} --}}
-
 <div class="row">
   <div class="large-12 columns medium-12 small-12">
     <section class="main-section new-user-section ui login_page book_appointment_headers">

--- a/app/templates/order/client_information.hbs
+++ b/app/templates/order/client_information.hbs
@@ -1,7 +1,3 @@
-{{!-- {{#if (is-and isMobileApp isClientSelected)}}
-  {{scroll-to-bottom }}
-{{/if}} --}}
-
 <div class="row">
   <div class="large-12 columns medium-12 small-12">
     <section class="main-section new-user-section ui login_page book_appointment_headers">

--- a/app/templates/order/confirm_booking.hbs
+++ b/app/templates/order/confirm_booking.hbs
@@ -1,7 +1,3 @@
-{{!-- {{#if isMobileApp}}
-  {{scroll-to-bottom }}
-{{/if}} --}}
-
 <div class="row">
   <div class="book large-12 columns medium-12 small-12">
     <section class="main-section new-user-section ui login_page large-12 medium-12 small-12">

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "ember-pretty-test": "^1.0.4",
     "ember-resolver": "^2.1.0",
     "ember-rollbar-client": "0.2.2",
-    "ember-scroll-to-bottom": "1.3.0",
     "ember-searchable-select": "^0.11.0",
     "ember-smart-banner": "0.1.3",
     "ember-welcome-page": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7870,14 +7870,6 @@ ember-runtime-enumerable-includes-polyfill@^2.0.0:
     ember-cli-babel "^6.9.0"
     ember-cli-version-checker "^2.1.0"
 
-ember-scroll-to-bottom@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/ember-scroll-to-bottom/-/ember-scroll-to-bottom-1.3.0.tgz#7b0318cc1baa77e7dd97ca872945a127e09d2780"
-  integrity sha512-1dhkLncYHekMO5xIqrsH8jlcqG4Lq6iwnZx7EcX2UtyPRilQi+9UVd3hCzIFiPNpT5v8hCJ2ur3WGFLIHDBgFw==
-  dependencies:
-    ember-cli-babel "^6.3.0"
-    ember-cli-sass "5.5.2"
-
 ember-searchable-select@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/ember-searchable-select/-/ember-searchable-select-0.11.0.tgz#785406483a8e1573f63880bebe1efd3aa79b2737"


### PR DESCRIPTION

### What does this PR do?

As per the title