### PR TITLE
GCW-3558- Logistics tab is empty when first viewed

### DIFF
--- a/app/routes/orders/detail.js
+++ b/app/routes/orders/detail.js
@@ -6,7 +6,7 @@ export default AuthorizeRoute.extend({
   currentRouteName: null,
 
   model({ order_id }) {
-    return this.loadIfAbsent("designation", order_id);
+    return this.get("store").findRecord("designation", order_id);
   },
 
   async afterModel() {


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3558

### What does this PR do?

This PR fixes issue of not loading `orderTransport` of orders if coming from dashboard. The dashboard does shallow loading which does not load associations. In the Order details page `loadIfAbsent` does not fetch a record if it is already present. So, I have added `findRecord` (without `reload: true`)  instead of `loadIfAbsent` in the logistic Tab to fix this problem.
