### PR TITLE
GCW-3424 - Fix pop up issue for the 'Process', 'Recycle', 'Trash', 'Gain (increase)', and 'Loss (decrease)'

### DIFF
--- a/app/routes/items/detail.js
+++ b/app/routes/items/detail.js
@@ -81,6 +81,7 @@ export default AuthorizeRoute.extend({
     controller.set("showExtendedFooterMenu", false);
     controller.set("displayResults", true);
     controller.set("containerQuantity", null);
+    controller.set("readyForAction", false);
 
     const defaultValue = await this.get("packageService").getItemValuation({
       donorConditionId: model.get("donorCondition.id"),


### PR DESCRIPTION


### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3424

### What does this PR do?
Fix below issue
The pop-ups from the 'Process', 'Recycle', 'Trash', 'Gain (increase)', and 'Loss (decrease)' options don't show when selecting the browser's/Pixel's Back button, but selecting the browser's Forward button/reselecting the item causes the pop-up to show again.