### PR TITLE
FIX: re-enable scan multiple on stocktakes

### DIFF
--- a/app/controllers/stocktakes/detail.js
+++ b/app/controllers/stocktakes/detail.js
@@ -251,14 +251,16 @@ export default Ember.Controller.extend(AsyncMixin, {
       this.saveChanges();
     },
 
+    stopScanning() {
+      this.stopScanning();
+    },
+
     /**
      * Will increment the revision for this pacakge by 1, or create it
      *
      * @param {Package} pkg
      */
-    async addItem(pkg) {
-      this.stopScanning();
-
+    async addItem(pkg, opts = {}) {
       pkg =
         pkg ||
         (await this.get("packageService").userPickPackage({

--- a/app/templates/stocktakes/detail.hbs
+++ b/app/templates/stocktakes/detail.hbs
@@ -83,7 +83,7 @@
               {{fa-icon 'lightbulb' size='lg'}}
             </button>
           {{/if}}
-          <button class="button ellipsis" {{action 'addItem'}}>
+          <button class="button ellipsis" {{action (multi-actions (action "stopScanning") (action "addItem"))}}>
             {{fa-icon 'plus'}} {{t 'stocktakes.add_item'}}
           </button>
         {{/if}}


### PR DESCRIPTION
The "stopScanning" method was being called right after an item was added, which prevented the scanner from scanning multiple items